### PR TITLE
Specify elastic search version to prevent the latest being used by default.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   elasticsearch:
-    image: elasticsearch
+    image: elasticsearch:2.4.2
     ports:
      - "9300:9300"
      - "9200:9200"


### PR DESCRIPTION
Specify elastic search version to prevent the latest being used by default.