### PR TITLE
updated readme and compose file to use specific postgres version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Created by .ignore support plugin (hsz.mobi)
+
+.idea

--- a/README.md
+++ b/README.md
@@ -7,3 +7,42 @@ https://www.docker.com/products/docker#/mac
 
 Run ```docker-compose up``` to create docker containers for all required backing services. Using the ``` ./run.sh ``` script does the same thing.
 
+
+## Postgres
+
+**Important**: Zebedee requires _**Postgres 9.6**_. 
+If you have error when Zebedee starts up due to a failed database connection make sure that your postgres images is version **9.6*
+
+The _dp-compose_postgres_ container by default uses port `5432` 
+
+### Checking postgres version
+
+`docker ps -a`
+
+You should see something similar to (see IMAGE):
+```
+CONTAINER ID    IMAGE           COMMAND                   CREATED           STATUS           PORTS                     NAMES
+d343558fd467    postgres:9.6    "docker-entrypoint.s…"    11 minutes ago    Up 11 minutes    0.0.0.0:5432->5432/tcp    dp-compose_postgres_1
+```
+
+Or (see TAG)
+```
+docker images
+```
+```
+REPOSITORY    TAG    IMAGE ID        CREATED       SIZE
+postgres      9.6    ed34a2d5eb79    3 days ago    230MB
+```
+
+If you have a newer version of postgres you can remove it:
+
+```
+docker rmi <IMAGE_ID>
+```
+
+### Connecting to Postgres
+To connect to the container and query via the postgres _cli_
+
+```
+docker run -it --rm --link dp-compose_postgres_1:postgres --net dp-compose_default postgres:9.6 psql -h postgres -U postgres
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     ports:
      - "9999:8080"
   postgres:
-    image: postgres:9.6
     build: ./postgres
     environment: 
      - POSTGRES_USER=postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     ports:
      - "9999:8080"
   postgres:
+    image: postgres:9.6
     build: ./postgres
     environment: 
      - POSTGRES_USER=postgres

--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,3 +1,3 @@
-FROM postgres
+FROM postgres:9.6
 
 COPY create_audit_db.sh /docker-entrypoint-initdb.d/create_audit_db.sh


### PR DESCRIPTION
Zebedee requires Postgres version 9.6 updated compose file to specify the version and updated READMe with useful information.