### PR TITLE
Add mongodb, neo4j, kafka and mathjax

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,16 @@ https://www.docker.com/products/docker#/mac
 
 Run ```docker-compose up``` to create docker containers for all required backing services. Using the ``` ./run.sh ``` script does the same thing.
 
+## Docker resourses
+NEO4J is quite resourse hungry so before running this it's worth increasing the RAM and CPU allocated to the docker
+virtual machine. This can be done from the
+[Docker Desktop preferences](https://docs.docker.com/docker-for-mac/#resources). Choosing the best figures is more of an
+art than a science, too little and these services won't run effectively, too much and it'll slow all the other apps
+running locally on your laptop but a good starting point is…
+- CPUs: 4 (So the services are not restricted by CPU)
+- Memory: 6.00GB
+- Swap: 4GB
+- Disk image size: 60GB (This is not particularly relevant and the figure here is the Docker default)
 
 ## CMD
 The ONS website and CMD both require Elastic search but (annoyingly) require different versions. The `docker-compose.yml` will start 2 instances. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     ports:
      - "9300:9300"
      - "9200:9200"
+    environment:
+     - "discovery.type=single-node"
   cmdelasticsearch:
     image: elasticsearch:5
     ports:
@@ -24,3 +26,34 @@ services:
      - POSTGRES_PASSWORD=mysecretpassword
     ports:
      - "5432:5432"
+  mongodb:
+    image: mongo
+    ports:
+      - 27017:27017
+  neo4j:
+    image: neo4j:3.2.12
+    ports:
+      - 7474:7474
+      - 7687:7687
+    environment:
+      - "NEO4J_AUTH=none"
+      - "NEO4J_dbms_memory_pagecache_size=5G"
+      - "NEO4J_dbms_memory_heap_max__size=5G"
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.11-1.0.2
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: localhost
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  mathjax:
+    image: onsdigital/mathjax-api
+    ports:
+      - "8888:8080"
+


### PR DESCRIPTION
Add mongodb, neo4j, kafka and mathjax to the docker-compose for backing services.

To review, pull the branch and run `docker-compose up` but beware if you have any of the services already running as they won't start.

