### PR TITLE
Fix mongodb version to match environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     ports:
      - "5432:5432"
   mongodb:
-    image: mongo
+    image: mongo:3.6
     ports:
       - 27017:27017
   neo4j:


### PR DESCRIPTION
Fix mongodb version to match environments. Both develop and production are using version 3.6.x. Without having a fixed version running dp-compose will default to the latest version. Having a mismatch is not ideal as we may not get a true reflection of how the services will run in environments.