### PR TITLE
Update cmd elasticsearch version to 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The ONS website and CMD both require Elastic search but (annoyingly) require dif
  when running 2 different versions on the same box at the same time the CMD instance is set to use ports `10200` & `10300`.
 
 :warning: **Gotcha Warning** :warning:
-You'll need to overwrite your ES config for the `dp-search-builder` and `dp-search-api` to use ports `10200` & `10300` to ensure they are using the correct instance.
+You'll need to overwrite your ES config for the `dp-search-builder` and `dp-dimension-search-api` to use ports `10200` & `10300` to ensure they are using the correct instance.
 
 ## Postgres
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
      - "discovery.type=single-node"
   cmdelasticsearch:
-    image: elasticsearch:5
+    image: elasticsearch:6.8.13
     ports:
       # Set alternative ports to prevent port clash.
       - 10300:9300


### PR DESCRIPTION
Update cmd elasticsearch version to match environments. Both develop and production are using version 6.x.x. Having a mismatch is not ideal as we may not get a true reflection of how the services will run in environments.