### PR TITLE
Use elastic official docker versions of elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     environment:
      - "discovery.type=single-node"
   cmdelasticsearch:
-    image: elasticsearch:6.8.13
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.0.0
     ports:
       # Set alternative ports to prevent port clash.
       - 10300:9300


### PR DESCRIPTION
See title

Also use version 6.0.0 instead of 6.8.13 as this is the version we are using in environments

Run `./run.sh --remove-orphans` and then run `curl localhost:10200 -vvvv` and check the response form the elasticsearch cluster. You will need to wait for dp-compose to finish spinning up all images before trying the curl command.