### PR TITLE
Remove Neo4j now that AWS Neptune is being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,6 @@ https://www.docker.com/products/docker#/mac
 
 Run ```docker-compose up``` to create docker containers for all required backing services. Using the ``` ./run.sh ``` script does the same thing.
 
-## Docker resourses
-NEO4J is quite resourse hungry so before running this it's worth increasing the RAM and CPU allocated to the docker
-virtual machine. This can be done from the
-[Docker Desktop preferences](https://docs.docker.com/docker-for-mac/#resources). Choosing the best figures is more of an
-art than a science, too little and these services won't run effectively, too much and it'll slow all the other apps
-running locally on your laptop but a good starting point is…
-- CPUs: 4 (So the services are not restricted by CPU)
-- Memory: 6.00GB
-- Swap: 4GB
-- Disk image size: 60GB (This is not particularly relevant and the figure here is the Docker default)
-
 ## CMD
 The ONS website and CMD both require Elastic search but (annoyingly) require different versions. The `docker-compose.yml` will start 2 instances. 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,15 +30,6 @@ services:
     image: mongo:3.6
     ports:
       - 27017:27017
-  neo4j:
-    image: neo4j:3.2.12
-    ports:
-      - 7474:7474
-      - 7687:7687
-    environment:
-      - "NEO4J_AUTH=none"
-      - "NEO4J_dbms_memory_pagecache_size=5G"
-      - "NEO4J_dbms_memory_heap_max__size=5G"
   zookeeper:
     image: wurstmeister/zookeeper
     ports:


### PR DESCRIPTION
Now that we are using AWS Neptune as a graph database provider, we no longer require Neo4j to run locally.

- remove Neo4j instance from docker-compose.yml
- remove details from readme about increasing system resources specifically for Neo4j
