### PR TITLE
281 Add Redis service to compose yml config.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,4 +47,12 @@ services:
     image: onsdigital/mathjax-api
     ports:
       - "8888:8080"
+  redis:
+    image: redis:6
+    command: redis-server --requirepass default
+    ports:
+      - "6379:6379"
+
+
+
 


### PR DESCRIPTION
See title.

When running docker compose, a local Redis service is successfully started.