### PR TITLE
Feature/add cantabular import journey

### DIFF
--- a/cantabular-import/.env
+++ b/cantabular-import/.env
@@ -1,0 +1,3 @@
+COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-cantabular-server.yml:dp-dataset-api.yml:dp-recipe-api.yml:zebedee.yml
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_PROJECT_NAME=cantabular-import-journey

--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -1,0 +1,36 @@
+### Cantabular Import Journey ###
+
+## Requirements ##
+
+Expects you to have environment variables `zebedee_root` and 
+`SERVICE_AUTH_TOKEN` set in your local environment
+
+Expects your services to be in the expected relative path
+
+# Bring Up Cantabular Import Services #
+
+`sudo docker-compose up`
+
+# Bring Up Cantabular Import Services Detached (running in background) #
+
+`sudo docker-compose up -d`
+
+# Stop Services #
+
+`docker-compose down`
+
+# Recall Logs For Specific Service #
+
+`docker-compose logs -f <service-name>` or `./logs <service-name>`
+
+## Notes ##
+
+# Making Changes #
+
+Go services will automatically rebuild upon detecting source file changes.
+
+If you need to make adjustments to compose files etc, you can just
+run `docker-compose up -d` and docker-compose will automatically detect 
+which services need rebuilding (no need to bring everything down first).
+
+

--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -7,6 +7,9 @@ Expects you to have environment variables `zebedee_root` and
 
 Expects your services to be in the expected relative path
 
+dp-dataset-api expects a connection to Neptune via ssh. Won't break
+import but health checks will fail and produce annoying messages.
+
 # Bring Up Cantabular Import Services #
 
 `sudo docker-compose up`

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -1,0 +1,26 @@
+version: '3.3'
+services:
+  mongodb:
+    image: mongo:3.6
+    ports:
+      - 27017:27017
+  zookeeper:
+    image: wurstmeister/zookeeper
+    ports:
+      - "2181:2181"
+  kafka:
+    image: wurstmeister/kafka:2.11-1.0.2
+    ports:
+      - "9092:9092"
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+  postgres:
+    build: ../postgres
+    environment: 
+     - POSTGRES_USER=postgres
+     - POSTGRES_PASSWORD=mysecretpassword
+    ports:
+     - "5432:5432"

--- a/cantabular-import/dp-cantabular-server.yml
+++ b/cantabular-import/dp-cantabular-server.yml
@@ -1,0 +1,11 @@
+version: '3.3'
+services:
+    dp-cantabular-server:
+        build:
+            context: ../../dp-cantabular-server
+            dockerfile: Dockerfile
+        ports:
+            - 8491:8491
+        volumes:
+            - ../../dp-cantabular-server/cantabular/data:/app/data
+            - ../../dp-cantabular-server/cantabular/scripts:/app/scripts

--- a/cantabular-import/dp-dataset-api.yml
+++ b/cantabular-import/dp-dataset-api.yml
@@ -22,3 +22,7 @@ services:
             ENABLE_PRIVATE_ENDPOINTS:      "true"
             ZEBEDEE_URL:                   "http://zebedee:8082"
             SERVICE_AUTH_TOKEN:            $SERVICE_AUTH_TOKEN
+            GRAPH_DRIVER_TYPE:             "neptune"
+            GRAPH_ADDR: "wss://localhost.cluster-cpviojtnaxsj.eu-west-1.neptune.amazonaws.com:8182/gremlin"
+
+

--- a/cantabular-import/dp-dataset-api.yml
+++ b/cantabular-import/dp-dataset-api.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+services:
+    dp-dataset-api:
+        build:
+            context: ../../dp-dataset-api
+            dockerfile: Dockerfile.local
+        command:
+            - reflex
+            - -d
+            - none
+            - -c
+            - ./reflex
+        volumes:
+            - ../../dp-dataset-api:/dp-dataset-api
+        depends_on:
+            - kafka
+        ports:
+            - 22000:22000
+        environment:
+            MONGODB_BIND_ADDR:             "mongodb:27017"
+            KAFKA_ADDR:                    "kafka:9092"
+            ENABLE_PRIVATE_ENDPOINTS:      "true"
+            ZEBEDEE_URL:                   "http://zebedee:8082"
+            SERVICE_AUTH_TOKEN:            $SERVICE_AUTH_TOKEN

--- a/cantabular-import/dp-import-api.yml
+++ b/cantabular-import/dp-import-api.yml
@@ -1,0 +1,26 @@
+version: '3.3'
+services:
+    dp-import-api:
+        build:
+            context: ../../dp-import-api
+            dockerfile: Dockerfile.local
+        command:
+            - reflex
+            - -d
+            - none
+            - -c
+            - ./reflex
+        volumes:
+            - ../../dp-import-api:/dp-import-api
+        depends_on:
+            - kafka
+        ports:
+            - 21800:21800
+        environment:
+            MONGODB_IMPORTS_ADDR:     "mongodb:27017"
+            KAFKA_ADDR:               "kafka:9092"
+            ENABLE_PRIVATE_ENDPOINTS: "true"
+            RECIPE_API_URL:           "http://dp-recipe-api:22300"
+            DATASET_API_URL:          "http://dp-dataset-api:22000"
+            ZEBEDEE_URL:              "http://zebedee:8082"
+            SERVICE_AUTH_TOKEN:       $SERVICE_AUTH_TOKEN

--- a/cantabular-import/dp-import-cantabular-dataset.yml
+++ b/cantabular-import/dp-import-cantabular-dataset.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+services:
+    dp-import-cantabular-dataset:
+        build:
+            context: ../../dp-import-cantabular-dataset
+            dockerfile: Dockerfile.local
+        command:
+            - reflex
+            - -d
+            - none
+            - -c
+            - ./reflex
+        volumes:
+            - ../../dp-import-cantabular-dataset:/dp-import-cantabular-dataset
+        depends_on:
+            - kafka
+        ports:
+            - 26100:26100
+        environment:
+            KAFKA_ADDR:         "kafka:9092"
+            DATASET_API_URL:    "http://dp-dataset-api:22000"
+            RECIPE_API_URL:     "http://dp-recipe-api:22300"
+            CANTABULAR_URL:     "http://dp-cantabular-server:8491"
+            SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN

--- a/cantabular-import/dp-recipe-api.yml
+++ b/cantabular-import/dp-recipe-api.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+services:
+    dp-recipe-api:
+        build:
+            context: ../../dp-recipe-api
+            dockerfile: Dockerfile.local
+        command:
+            - reflex
+            - -d
+            - none
+            - -c
+            - ./reflex
+        volumes:
+            - ../../dp-recipe-api:/dp-recipe-api
+        depends_on:
+            - kafka
+        ports:
+            - 22300:22300
+        environment:
+            MONGODB_BIND_ADDR:        "mongodb:27017"
+            KAFKA_ADDR:               "kafka:9092"
+            ENABLE_PRIVATE_ENDPOINTS: "true"
+            ZEBEDEE_URL:              "http://zebedee:8082"
+            SERVICE_AUTH_TOKEN:       $SERVICE_AUTH_TOKEN

--- a/cantabular-import/logs
+++ b/cantabular-import/logs
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker-compose logs -f $1

--- a/cantabular-import/zebedee.yml
+++ b/cantabular-import/zebedee.yml
@@ -1,0 +1,38 @@
+version: '3.3'
+services:
+    zebedee:
+        build:
+            context: ../../zebedee
+            dockerfile: Dockerfile
+        command:
+            - reflex
+            - -d
+            - none
+            - -c
+            - ./reflex
+        volumes:
+            - ../../dp-recipe-api:/dp-recipe-api
+        depends_on:
+            - kafka
+        ports:
+            - 8082:8082
+        volumes:
+            - $zebedee_root:/zebedee_root
+        environment:
+            DATASET_API_URL:        "http://dp-dataset-api:22000"
+            DATASET_API_AUTH_TOKEN: "FD0108EA-825D-411C-9B1D-41EF7727F465"
+            ENABLE_PERMISSIONS_AUTH: "true"
+            ENABLE_DATASET_IMPORT:   "true"
+            FORMAT_LOGGING:          "true"
+            JAVA_OPTS:               " -Xmx1204m -Xdebug -Xrunjdwp:transport=dt_socket,address=8002,server=y,suspend=n"
+            PORT:                    "8082"
+            RESTOLINO_STATIC:        "src/main/resources/files"
+            RESTOLINO_CLASSES:       "zebedee-cms/target/classes"
+            PACKAGE_PREFIX:          "com.github.onsdigital.zebedee"
+            audit_db_enabled:        "false"
+            enable_splunk_reporting: "false"
+            zebedee_root:            "/zebedee_root"
+            SERVICE_AUTH_TOKEN:      $SERVICE_AUTH_TOKEN
+            db_audit_url:            "jdbc:postgresql://localhost:5432/audit"
+            db_audit_username:       "postgres"
+            db_audit_password:       "mysecretpassword"


### PR DESCRIPTION
Created a docker-compose setup for the Cantabular import journey

These changes depend on the new Dockerfiles and changes added to:

dp-dataset-api
dp-recipe-api
dp-import-api
dp-import-cantabular-dataset

So either those PRs will need to be merged before testing this, or you can checkout the relevant branch for those services (feature/add-local-dockerfile)

How To Test:

Run `docker-compose-up` or one of it's variants, verify services all start and health checks return 200... mostly. dp-dataset-api returns 500 for it's health check for an unknown reason (even though the service runs fine). This also happens when running outside of docker-compose.

You can test the entire import journey by posting an import job request to import-api. There is a script that's been written for this, I will attach it in a message in the slack channel. 