### PR TITLE
use bitnami kafka image. Add mongo init script

### DIFF
--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -7,16 +7,13 @@ Expects you to have environment variables `zebedee_root` and
 
 Expects your services to be in the expected relative path
 
-dp-dataset-api expects a connection to Neptune via ssh. Won't break
-import but health checks will fail and produce annoying messages.
-
 # Bring Up Cantabular Import Services #
 
-`sudo docker-compose up`
+`sudo -E docker-compose up` or `./run.sh`
 
 # Bring Up Cantabular Import Services Detached (running in background) #
 
-`sudo docker-compose up -d`
+`sudo -E docker-compose up -d`
 
 # Stop Services #
 
@@ -36,4 +33,16 @@ If you need to make adjustments to compose files etc, you can just
 run `docker-compose up -d` and docker-compose will automatically detect 
 which services need rebuilding (no need to bring everything down first).
 
+## Known Issues ##
+
+dp-dataset-api requires a connection to a graph db in order to not complain
+at healthcheck time. As it stands the service isn't configured to be able
+to access the ssh tunnel to Neptune from the container's host machine.
+
+This doesn't prevent the Cantabular import journey from working but it does
+produce an error log.
+
+Either dp-dataset-api needs to be able to be configured to not require a
+graph db connection or the container needs to be configured to access the
+host environments localhost.
 

--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -7,6 +7,9 @@ Expects you to have environment variables `zebedee_root` and
 
 Expects your services to be in the expected relative path
 
+You will need to run the `import-recipes` script in `dp-recipe-api` when
+first building the containers before running an import.
+
 # Bring Up Cantabular Import Services #
 
 `sudo -E docker-compose up` or `./run.sh`

--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -2,17 +2,30 @@
 
 ## Requirements ##
 
+Make sure you have the following repositories cloned to the same root directory
+as `dp-compose` (this repository):
+
+`dp-cantabular-server`
+`dp-dataset-api`
+`dp-import-api`
+`dp-import-cantabular-dataset`
+`dp-import-cantabular-dimension-options`
+`dp-recipe-api`
+`zebedee`
+
 Expects you to have environment variables `zebedee_root` and 
 `SERVICE_AUTH_TOKEN` set in your local environment
-
-Expects your services to be in the expected relative path
 
 You will need to run the `import-recipes` script in `dp-recipe-api` when
 first building the containers before running an import.
 
 # Bring Up Cantabular Import Services #
 
-`sudo -E docker-compose up` or `./run.sh`
+`sudo -E docker-compose up` (or `./run.sh` helper)
+
+(note: we use `sudo` to prevent docker having issues accessing the `GOCACHE`
+volume it creates. `sudo` requires the `-E` in order to preserve existing
+environment variables)
 
 # Bring Up Cantabular Import Services Detached (running in background) #
 
@@ -24,7 +37,7 @@ first building the containers before running an import.
 
 # Recall Logs For Specific Service #
 
-`docker-compose logs -f <service-name>` or `./logs <service-name>`
+`docker-compose logs -f <service-name>` (or `./logs <service-name>` helper)
 
 ## Notes ##
 

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -4,19 +4,26 @@ services:
     image: mongo:3.6
     ports:
       - 27017:27017
-  zookeeper:
-    image: wurstmeister/zookeeper
-    ports:
-      - "2181:2181"
-  kafka:
-    image: wurstmeister/kafka:2.11-1.0.2
-    ports:
-      - "9092:9092"
-    environment:
-      KAFKA_ADVERTISED_HOST_NAME: kafka
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - ./mongodb/entrypoint-initdb.d/init.js:/docker-entrypoint-initdb.d/init.js:ro
+  zookeeper:
+    image: 'bitnami/zookeeper:latest'
+    hostname: zookeeper
+    restart: unless-stopped
+    ports:
+      - '2181:2181'
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'bitnami/kafka:latest'
+    hostname: kafka
+    restart: unless-stopped
+    ports:
+      - '9092:9092'
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
   postgres:
     build: ../postgres
     environment: 

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -5,6 +5,7 @@ services:
     ports:
       - 27017:27017
     volumes:
+      # Load init script to ensure dbs and collections are created
       - ./mongodb/entrypoint-initdb.d/init.js:/docker-entrypoint-initdb.d/init.js:ro
   zookeeper:
     image: 'bitnami/zookeeper:latest'

--- a/cantabular-import/dp-dataset-api.yml
+++ b/cantabular-import/dp-dataset-api.yml
@@ -24,5 +24,3 @@ services:
             SERVICE_AUTH_TOKEN:            $SERVICE_AUTH_TOKEN
             GRAPH_DRIVER_TYPE:             "neptune"
             GRAPH_ADDR: "wss://localhost.cluster-cpviojtnaxsj.eu-west-1.neptune.amazonaws.com:8182/gremlin"
-
-

--- a/cantabular-import/mongodb/entrypoint-initdb.d/init.js
+++ b/cantabular-import/mongodb/entrypoint-initdb.d/init.js
@@ -1,0 +1,30 @@
+var databases = [
+	{
+		name: "datasets",
+		collections: ["datasets", "instances", "editions", "dimension.options"]
+	},
+	{
+		name: "recipes",
+		collections: ["recipes"]
+	},
+	{
+		name: "filters",
+		collections: ["filters", "filterOutputs"]
+	},
+	{
+		name: "imports",
+		collections: ["imports"]
+	},
+	{
+		name: "search",
+		collections: ["jobs", "jobs_locks"]
+	}
+];
+
+for (database of databases) {
+	db = db.getSiblingDB(database.name);
+
+	for (collection of database.collections){
+		db.createCollection(collection);
+	}
+}

--- a/cantabular-import/run.sh
+++ b/cantabular-import/run.sh
@@ -1,0 +1,1 @@
+sudo -E docker-compose up


### PR DESCRIPTION
- Switched to Bitnami Kafka image as it seems more stable. Wurmeister would often get stuck in leadership elections and other issues.
- Added an initialisation script to MongoDB to create required collections. This removes the need to manually create them each time you build the containers.

## How To Test ##

- Remove containers (docker-compose down -v) and rebuild (./run.sh)

- Check Kafka stabalises after a period time and services are able to connect 
  - You will stop seeing this log message: `error": "kafka: client has run out of available brokers to talk to (Is your cluster reachable?)"`
  - And start seeing this one: `"event": "sarama consumer group session setup ok: a new go-routine will be created for each partition assigned to this consumer"`
- Check health endpoints. All services should return healthy for Kafka and MongoDB
