### PR TITLE
update comments & readme, reorganise dir structure

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-dataset-api.yml:dp-recipe-api.yml:zebedee.yml
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_PROJECT_NAME=cantabular-import-journey

--- a/cantabular-import/Makefile
+++ b/cantabular-import/Makefile
@@ -1,0 +1,27 @@
+.PHONY: start
+start:
+	@echo "starting containers"
+	sudo -E docker-compose up
+.PHONY: start-detached
+start-detached:
+	@echo "starting containers in background"
+	sudo -E docker-compose up -d
+.PHONY: stop
+stop:
+	@echo "stopping containers"
+	docker-compose stop
+.PHONY: down
+down:
+	@echo "stopping and removing containers and networks"
+	docker-compose down
+.PHONY: clean
+clean:
+	@echo "stopping and removing containers, associated volumes and networks"
+	docker-compose down -v
+.PHONY: restart
+restart:
+	@echo "restarting containers"
+	docker-compose restart
+.PHONY: logs
+logs:
+	./logs $t

--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -21,7 +21,7 @@ first building the containers before running an import.
 
 # Bring Up Cantabular Import Services #
 
-`sudo -E docker-compose up` (or `./run.sh` helper)
+`make start`
 
 (note: we use `sudo` to prevent docker having issues accessing the `GOCACHE`
 volume it creates. `sudo` requires the `-E` in order to preserve existing
@@ -29,15 +29,31 @@ environment variables)
 
 # Bring Up Cantabular Import Services Detached (running in background) #
 
-`sudo -E docker-compose up -d`
+`make start-detached`
 
 # Stop Services #
 
-`docker-compose down`
+`make stop`
+
+# Stop Services And Remove Containers #
+
+`make down`
+
+# Stop Services And Remove All Containers, Volumes and Networks #
+
+`make clean`
+
+# Restart Services #
+
+`make restart`
+
+# Recall Logs #
+
+`make logs` or `./logs`
 
 # Recall Logs For Specific Service #
 
-`docker-compose logs -f <service-name>` (or `./logs <service-name>` helper)
+`make logs t=<service-name>` or `./logs <service-name>`
 
 ## Notes ##
 
@@ -46,11 +62,5 @@ environment variables)
 Go services will automatically rebuild upon detecting source file changes.
 
 If you need to make adjustments to compose files etc, you can just
-run `docker-compose up -d` and docker-compose will automatically detect 
+run `make start-detached` and docker-compose will automatically detect 
 which services need rebuilding (no need to bring everything down first).
-
-## Other Info ##
-
-dp-dataset-api requires a connection to a graph db in order to not complain
-at healthcheck time, but it isn't used at all during this journey.
-For this reason the neo4j image is included in the stack.

--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -49,16 +49,8 @@ If you need to make adjustments to compose files etc, you can just
 run `docker-compose up -d` and docker-compose will automatically detect 
 which services need rebuilding (no need to bring everything down first).
 
-## Known Issues ##
+## Other Info ##
 
 dp-dataset-api requires a connection to a graph db in order to not complain
-at healthcheck time. As it stands the service isn't configured to be able
-to access the ssh tunnel to Neptune from the container's host machine.
-
-This doesn't prevent the Cantabular import journey from working but it does
-produce an error log.
-
-Either dp-dataset-api needs to be able to be configured to not require a
-graph db connection or the container needs to be configured to access the
-host environments localhost.
-
+at healthcheck time, but it isn't used at all during this journey.
+For this reason the neo4j image is included in the stack.

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -32,12 +32,3 @@ services:
      - POSTGRES_PASSWORD=mysecretpassword
     ports:
     - 5432:5432
-  neo4j:
-    image: neo4j:3.2.12
-    ports:
-      - 7474:7474
-      - 7687:7687
-    environment:
-      - "NEO4J_AUTH=none"
-      - "NEO4J_dbms_memory_pagecache_size=5G"
-      - "NEO4J_dbms_memory_heap_max__size=5G"

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -31,4 +31,13 @@ services:
      - POSTGRES_USER=postgres
      - POSTGRES_PASSWORD=mysecretpassword
     ports:
-     - "5432:5432"
+    - 5432:5432
+  neo4j:
+    image: neo4j:3.2.12
+    ports:
+      - 7474:7474
+      - 7687:7687
+    environment:
+      - "NEO4J_AUTH=none"
+      - "NEO4J_dbms_memory_pagecache_size=5G"
+      - "NEO4J_dbms_memory_heap_max__size=5G"

--- a/cantabular-import/dp-dataset-api.yml
+++ b/cantabular-import/dp-dataset-api.yml
@@ -22,7 +22,4 @@ services:
             ENABLE_PRIVATE_ENDPOINTS:      "true"
             ZEBEDEE_URL:                   "http://zebedee:8082"
             SERVICE_AUTH_TOKEN:            $SERVICE_AUTH_TOKEN
-            GRAPH_DRIVER_TYPE:             "neptune"
-            GRAPH_ADDR: "wss://localhost.cluster-cpviojtnaxsj.eu-west-1.neptune.amazonaws.com:8182/gremlin"
             DISABLE_GRAPH_DB_DEPENDENCY:   "true"
-            

--- a/cantabular-import/dp-import-cantabular-dataset.yml
+++ b/cantabular-import/dp-import-cantabular-dataset.yml
@@ -22,4 +22,5 @@ services:
             DATASET_API_URL:    "http://dp-dataset-api:22000"
             RECIPE_API_URL:     "http://dp-recipe-api:22300"
             CANTABULAR_URL:     "http://dp-cantabular-server:8491"
+            IMPORT_API_URL:     "http://dp-import-api:21800"
             SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN

--- a/cantabular-import/helpers/README.md
+++ b/cantabular-import/helpers/README.md
@@ -20,7 +20,7 @@ Usage:
 
 * Edit the `./florence-token` script to use your florence username/password
 
-* Run `./start-import`
+* Run `./start-import.sh`
 
 Alternatively if you have your own script/other source to get a florence token
 you can pipe the output directly into `go run start-import/main.go`

--- a/cantabular-import/helpers/README.md
+++ b/cantabular-import/helpers/README.md
@@ -1,0 +1,29 @@
+### Helper scripts ###
+
+Find here a some scripts to help with working with the Cantabular import process
+
+## florence-token ##
+
+`florence-token` returns a fresh florence token to use with requests that require
+it.
+
+Usage: edit `florence-token` to have your username/password and run
+`./florence-token`
+
+## start-import.sh ##
+
+`start-import.sh` starts an import of the Example Cantabular Dataset.
+
+Usage: 
+* Make sure you have your Cantabular Import Journey set as per
+`cantabular-import/README.md`
+
+* Edit the `./florence-token` script to use your florence username/password
+
+* Run `./start-import`
+
+Alternatively if you have your own script/other source to get a florence token
+you can pipe the output directly into `go run start-import/main.go`
+
+for example, if you had a FLORENCE_TOKEN environment variable saved you could run
+`echo $FLORENCE_TOKEN | go run start-import/main.go`

--- a/cantabular-import/helpers/florence-token
+++ b/cantabular-import/helpers/florence-token
@@ -1,0 +1,2 @@
+url=http://localhost:8082/login
+curl -d '{"email":"florence@magicroundabout.ons.gov.uk","password":"<your password here>"}' $url

--- a/cantabular-import/helpers/start-import.sh
+++ b/cantabular-import/helpers/start-import.sh
@@ -1,0 +1,2 @@
+echo "retrieving florence token:" 
+./florence-token | go run start-import/main.go

--- a/cantabular-import/helpers/start-import/main.go
+++ b/cantabular-import/helpers/start-import/main.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"net/http"
+	"bufio"
+	"io/ioutil"
+	"io"
+	"os"
+	"fmt"
+	"encoding/json"
+	"bytes"
+)
+
+type PutJobRequest struct{
+	Links Links  `json:"links"`
+	State string `json:"state"`
+}
+
+type PostJobResponse struct{
+	ID string   `json:"id"`
+	Links Links `json:"links"`
+}
+
+type Links struct{
+	Instances []Link `json:"instances"`
+	Self Link        `json:"self"`
+}
+
+type Link struct{
+	ID   string `json: "id"`
+	HRef string `json:"href"`
+}
+
+var (
+	importAPIHost = "http://localhost:21800"
+	recipeID =      "38542eb6-d3a6-4cc4-ba3f-32b25f23223a"
+
+	client = &http.Client{}
+)
+
+func main(){
+	token, err := readInput()
+	if err != nil{
+		fmt.Println("error reading input: ", err)
+	}
+
+	res, err := postJob(token)
+	if err != nil{
+		fmt.Println("error posting job to importAPI: ", err)
+		os.Exit(1)
+	}
+
+	if err := putJob(token, res); err != nil{
+		fmt.Println("error putting job to importAPI: ", err)
+		os.Exit(1)
+	}
+}
+
+func readInput() (string, error){
+	rdr := bufio.NewReader(os.Stdin)
+
+	s, err := rdr.ReadString('\n')
+	if err != nil && err != io.EOF{
+		return "", fmt.Errorf("failed to read from stdin: %s", err)
+	}
+
+	fmt.Println("florence-token:", s)
+
+	return s, nil
+}
+
+func postJob(token string) (*PostJobResponse, error){
+	fmt.Printf("Making request to POST import-api/jobs:")
+
+	b := []byte(fmt.Sprintf(`{"recipe":"%s"}`, recipeID))
+
+	fmt.Println(string(b))
+
+	r, err :=  http.NewRequest("POST", importAPIHost + "/jobs", bytes.NewReader(b))
+	if err != nil{
+		return nil, fmt.Errorf("error creating request: %s", err)
+	}
+
+	r.Header.Set("X-Florence-Token", token)
+
+	res, err := client.Do(r)
+	if err != nil{
+		return nil, fmt.Errorf("error performing request: %s", err)
+	}
+	defer res.Body.Close()
+
+	var resp PostJobResponse
+
+	b, err = ioutil.ReadAll(res.Body)
+	if err != nil{
+		return nil, fmt.Errorf("error reading response body: %s", err)
+	}
+
+	if err := json.Unmarshal(b, &resp); err != nil{
+		r := fmt.Sprintf("%d %s", res.StatusCode, string(b))
+		return nil, fmt.Errorf("error unmarshalling response: '%s' response: %s\n", err, r)
+	}
+
+	fmt.Printf("Got response from POST import-api/jobs: %s\n", prettyPrint(resp))
+	return &resp, nil
+}
+
+func putJob(token string, resp *PostJobResponse) error{
+	fmt.Println("Making request to PUT import-api/jobs:")
+
+	req := PutJobRequest{
+		State: "submitted",
+		Links: resp.Links,
+	}
+
+	b, err := json.Marshal(req)
+	if err != nil{
+		return fmt.Errorf("error marshalling request: %s request:\n%+v", err, req)
+	}
+
+	fmt.Println(prettyPrint(req))
+
+	r, err :=  http.NewRequest("PUT", importAPIHost + "/jobs/" + resp.ID, bytes.NewReader(b))
+	if err != nil{
+		return fmt.Errorf("error creating request: %s", err)
+	}
+
+	r.Header.Set("X-Florence-Token", token)
+
+	res, err := client.Do(r)
+	if err != nil{
+		return fmt.Errorf("error making request: %s", err)
+	}
+	defer res.Body.Close()
+
+	b, err = ioutil.ReadAll(res.Body)
+	if err != nil{
+		return fmt.Errorf("error reading response body: %s", err)
+	}
+
+	fmt.Printf("Got response from PUT import-api/jobs/%s: %d\n", resp.ID, res.StatusCode)
+	fmt.Println(prettyPrint(string(b)))
+
+	return nil
+}
+
+func prettyPrint(s interface{}) string {
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err == nil{
+		return fmt.Sprintf("%s", string(b))
+	} else {
+		return fmt.Sprintf("%+v", s)
+	}
+}

--- a/cantabular-import/helpers/start-import/main.go
+++ b/cantabular-import/helpers/start-import/main.go
@@ -27,7 +27,7 @@ type Links struct{
 }
 
 type Link struct{
-	ID   string `json: "id"`
+	ID   string `json:"id"`
 	HRef string `json:"href"`
 }
 

--- a/cantabular-import/run-cantabular.sh
+++ b/cantabular-import/run-cantabular.sh
@@ -1,1 +1,0 @@
-sudo -E docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,3 @@ services:
     command: redis-server --requirepass default
     ports:
       - "6379:6379"
-
-
-
-


### PR DESCRIPTION
Added helper scripts for kicking off the Cantabular Import journey

## How to test ##

Set up the Cantabular import journey as per `cantabular-import/README.md`

Run `cantabular-import.sh` script as per `cantabular-import/helpers/README.md`

Check import process starts successfully. You should received 200 responses from the import-script
and check `dp-import-cantabular-dataset` logs for `event successfully processed`

(there is work ongoing between dp-import-cantabular-dimension-options and dp-dataset-api that prevents the import completing fully without errors currently, this PR is just for the trigger mechanism helper script)