### PR TITLE
Show times between id's and which id has largest time differential

### DIFF
--- a/cantabular-import/helpers/extract-job-info/extract-job-info.go
+++ b/cantabular-import/helpers/extract-job-info/extract-job-info.go
@@ -141,7 +141,7 @@ func main() {
 						maxDiffTime = fields[1]
 					}
 					maxLastTime = fields[1]
-					printAndSave(idResultFile, fmt.Sprintf("time since last id: %d.%09d seconds", diffNanoseconds/1000000000, diffNanoseconds%1000000000))
+					printAndSave(idResultFile, fmt.Sprintf("time since last id: %.9f seconds", diffNanoseconds.Seconds()))
 				}
 			} else {
 				gotFirstTime = true
@@ -166,7 +166,7 @@ func main() {
 			printAndSave(idResultFile, fmt.Sprintf("   first event time: %s", firstTime))
 			printAndSave(idResultFile, fmt.Sprintf("    last event time: %s", lastTime))
 			if idsFound > 1 {
-				printAndSave(idResultFile, fmt.Sprintf("max id execution time is: %d.%09d seconds, finishing at: %s\n", maxDiff/1000000000, maxDiff%1000000000, maxDiffTime))
+				printAndSave(idResultFile, fmt.Sprintf("max id execution time is: %.9f seconds, finishing at: %s\n", maxDiff.Seconds(), maxDiffTime))
 				sort.SliceStable(diffsFound, func(i, j int) bool {
 					// compare the durations
 					return diffsFound[i] < diffsFound[j]
@@ -185,7 +185,7 @@ func main() {
 					}
 				}
 				printAndSave(idResultFile, fmt.Sprintf("Largest ~10%% of diffsFound adds up to: %v\n", topTenTotal))
-				printAndSave(idResultFile, fmt.Sprintf("Which is %%%v of the total\n", (100*topTenTotal.Nanoseconds())/total.Nanoseconds()))
+				printAndSave(idResultFile, fmt.Sprintf("Which is %v%% of the total\n", (100*topTenTotal.Nanoseconds())/total.Nanoseconds()))
 			}
 
 			f, ferr := time.Parse(time.RFC3339, firstTime) // time format with nanoseconds
@@ -204,7 +204,7 @@ func main() {
 
 				diffNanoseconds := lTime.Sub(fTime)
 
-				printAndSave(idResultFile, fmt.Sprintf("Job execution time is: %d.%09d seconds\n", diffNanoseconds/1000000000, diffNanoseconds%1000000000))
+				printAndSave(idResultFile, fmt.Sprintf("Job execution time is: %.9f seconds\n", diffNanoseconds.Seconds()))
 			}
 		}
 	}


### PR DESCRIPTION
Visual inspection of changes should be fine.

The last part of a run of this app against an extracted log file for a single import gives this output:
-=-=-
/cantabular-import-journey_dp-import-api_1                          2021-08-04T16:59:41.548685793Z     "job_id": "7fdc3807-3891-4278-8a73-503d621b317a"
execution time: 0.001339885 seconds
/cantabular-import-journey_dp-import-api_1                          2021-08-04T16:59:41.550025678Z     "path": "/jobs/7fdc3807-3891-4278-8a73-503d621b317a",
execution time: 0.001565649 seconds
/cantabular-import-journey_dp-import-cantabular-dimension-options_1 2021-08-04T16:59:41.551591327Z       "JobID": "7fdc3807-3891-4278-8a73-503d621b317a"
Number of ID's found is: 78
     Job start time: 2021-08-04T17:59:40.279641000Z
   first event time: 2021-08-04T16:59:40.410780460Z
    last event time: 2021-08-04T16:59:41.551591327Z
max id execution time is: 0.195302061 seconds, finishing at: 2021-08-04T16:59:41.180388877Z

diffs: [2.709µs 2.748µs 2.75µs 8.332µs 9.35µs 10.724µs 12.151µs 12.156µs 13.431µs 13.681µs 15.346µs 15.496µs 19.661µs 29.956µs 37.811µs 38.001µs 47.061µs 49.848µs 73.541µs 75.353µs 163.675µs 191.296µs 233.485µs 586.129µs 631.59µs 835.315µs 858.764µs 865.677µs 925.75µs 953.666µs 1.114859ms 1.195462ms 1.339885ms 1.364376ms 1.36749ms 1.521166ms 1.565649ms 1.903367ms 2.081514ms 2.122712ms 2.199622ms 2.558781ms 2.612119ms 2.676389ms 2.834248ms 2.935008ms 2.952275ms 2.97402ms 3.89381ms 3.913883ms 4.636504ms 4.976715ms 5.583248ms 6.368515ms 6.448791ms 7.238107ms 10.25343ms 10.625676ms 10.646626ms 11.14733ms 11.493386ms 13.393699ms 16.534261ms 18.298822ms 20.719929ms 20.9176ms 29.622639ms 31.298333ms 45.053682ms 46.650058ms 53.727944ms 70.881847ms 70.976512ms 92.10229ms 135.645372ms 138.405402ms 195.302061ms]

len of diffs: 77

Largest ~10% of diffsFound adds up to: 803.691486ms

Which is 70% of the total

Job execution time is: 1.140810867 seconds

Total Jobs: 1
-=-=-

Showing the added times between id's of a job in the log and also which id has the most amount of time between it and its previous occurence.