### PR TITLE
Integrate dp-cantabular-csv-exporter dockerfile

### DIFF
--- a/cantabular-import/.env
+++ b/cantabular-import/.env
@@ -1,3 +1,3 @@
-COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-dataset-api.yml:dp-recipe-api.yml:zebedee.yml
+COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-dataset-api.yml:dp-cantabular-csv-exporter.yml:dp-recipe-api.yml:zebedee.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=cantabular-import-journey

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -34,3 +34,10 @@ services:
      - POSTGRES_PASSWORD=mysecretpassword
     ports:
     - 5432:5432
+  minio:
+    image: 'bitnami/minio:latest'
+    ports:
+      - '9000:9000'
+    environment:
+      - MINIO_ACCESS_KEY=minio-access-key
+      - MINIO_SECRET_KEY=minio-secret-key

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -41,3 +41,4 @@ services:
     environment:
       - MINIO_ACCESS_KEY=minio-access-key
       - MINIO_SECRET_KEY=minio-secret-key
+      

--- a/cantabular-import/dp-cantabular-csv-exporter.yml
+++ b/cantabular-import/dp-cantabular-csv-exporter.yml
@@ -17,6 +17,7 @@ services:
         ports:
             - 26300:26300
         environment:
+            BIND_ADDR:          ":26300"
             KAFKA_ADDR:         "kafka:9092"
             DATASET_API_URL:    "http://dp-dataset-api:22000"
             RECIPE_API_URL:     "http://dp-recipe-api:22300"

--- a/cantabular-import/dp-cantabular-csv-exporter.yml
+++ b/cantabular-import/dp-cantabular-csv-exporter.yml
@@ -1,0 +1,24 @@
+version: '3.3'
+services:
+    dp-cantabular-csv-exporter:
+        build:
+            context: ../../dp-cantabular-csv-exporter
+            dockerfile: Dockerfile.local
+        command:
+            - reflex
+            - -d
+            - none
+            - -c
+            - ./reflex
+        volumes:
+            - ../../dp-cantabular-csv-exporter:/dp-cantabular-csv-exporter
+        depends_on:
+            - kafka
+        ports:
+            - 26300:26300
+        environment:
+            KAFKA_ADDR:         "kafka:9092"
+            DATASET_API_URL:    "http://dp-dataset-api:22000"
+            RECIPE_API_URL:     "http://dp-recipe-api:22300"
+            CANTABULAR_URL:     "http://dp-cantabular-server:8491"
+            SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN


### PR DESCRIPTION
- Integrate dp-cantabular-csv-exporter dockerfile
- Integrate minio as local emulation of Amazon S3

Trello - https://trello.com/c/SP0Yhuc5/5190-add-local-dockerfile-for-dp-cantabular-csv-exporter-and-integrate-into-dp-compose-cantabular-import-journey