### PR TITLE
add cantabular-api-ext to cantabular compose journey

### DIFF
--- a/cantabular-import/.env
+++ b/cantabular-import/.env
@@ -1,3 +1,3 @@
-COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-dataset-api.yml:dp-cantabular-csv-exporter.yml:dp-recipe-api.yml:zebedee.yml
+COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-cantabular-api-ext.yml:dp-dataset-api.yml:dp-cantabular-csv-exporter.yml:dp-recipe-api.yml:zebedee.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=cantabular-import-journey

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -41,4 +41,3 @@ services:
     environment:
       - MINIO_ACCESS_KEY=minio-access-key
       - MINIO_SECRET_KEY=minio-secret-key
-      

--- a/cantabular-import/dp-cantabular-api-ext.yml
+++ b/cantabular-import/dp-cantabular-api-ext.yml
@@ -1,0 +1,13 @@
+version: '3.3'
+services:
+    dp-cantabular-api-ext:
+        build:
+            context: ../../dp-cantabular-api-ext
+            dockerfile: Dockerfile
+        ports:
+            - 8492:8492
+        volumes:
+            - ../../dp-cantabular-api-ext/cantabular/data:/app/data
+            - ../../dp-cantabular-api-ext/cantabular/scripts:/app/scripts
+        environment:
+            CANTABULAR_API_URL: "http://dp-cantabular-server:8491"

--- a/cantabular-import/dp-cantabular-csv-exporter.yml
+++ b/cantabular-import/dp-cantabular-csv-exporter.yml
@@ -17,9 +17,10 @@ services:
         ports:
             - 26300:26300
         environment:
-            BIND_ADDR:          ":26300"
-            KAFKA_ADDR:         "kafka:9092"
-            DATASET_API_URL:    "http://dp-dataset-api:22000"
-            RECIPE_API_URL:     "http://dp-recipe-api:22300"
-            CANTABULAR_URL:     "http://dp-cantabular-server:8491"
+            BIND_ADDR:              ":26300"
+            KAFKA_ADDR:             "kafka:9092"
+            DATASET_API_URL:        "http://dp-dataset-api:22000"
+            RECIPE_API_URL:         "http://dp-recipe-api:22300"
+            CANTABULAR_URL:         "http://dp-cantabular-server:8491"
+            CANTABULAR_EXT_API_URL: "http://dp-cantabular-api-ext:8492"
             SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN


### PR DESCRIPTION
- Added dp-cantabular-api-ext to Cantabular import journey, for use with CSV exporter GraphQL queries.

## How to review ##

Make sure code changes make sense.

To test locally, run make set up in `cantabular-import` and check service `dp-cantabular-api-ext` runs correctly