### PR TITLE
Sort container names, Add http request bounding boxes

### DIFF
--- a/cantabular-import/analysis/extract-docker-logs/extract-docker-logs.go
+++ b/cantabular-import/analysis/extract-docker-logs/extract-docker-logs.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	dockerLogName      = "../tmp/all-container-logs.txt"
-	maxContainersInJob = 14 // adjust this to suite the number of continers docker-compose runs up
+	maxContainersInJob = 14 // adjust this to suite the number of continers docker-compose runs up for cantabular
 )
 
 // It can take a while to read all container logs, so all logs are read into one file and then this file is


### PR DESCRIPTION
1. Sort container names, so that different graphs for different job id runs place container names, etc in same place - this done because sometimes the graph could start from a different container.
2. Add blue bounding boxes around events that are wrapped by middleware adding events for 'http request started' and 'http request completed'. This helps to visualise things much better.