### PR TITLE
Added download service to compose

### DIFF
--- a/cantabular-import/.env
+++ b/cantabular-import/.env
@@ -1,3 +1,3 @@
-COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-cantabular-api-ext.yml:dp-dataset-api.yml:dp-cantabular-csv-exporter.yml:dp-recipe-api.yml:zebedee.yml
+COMPOSE_FILE=deps.yml:dp-import-api.yml:dp-import-cantabular-dataset.yml:dp-import-cantabular-dimension-options.yml:dp-cantabular-server.yml:dp-cantabular-api-ext.yml:dp-dataset-api.yml:dp-cantabular-csv-exporter.yml:dp-recipe-api.yml:zebedee.yml:dp-download-service.yml
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=cantabular-import-journey

--- a/cantabular-import/dp-download-service.yml
+++ b/cantabular-import/dp-download-service.yml
@@ -1,8 +1,8 @@
 version: '3.3'
 services:
-    dp-cantabular-csv-exporter:
+    dp-download-service:
         build:
-            context: ../../dp-cantabular-csv-exporter
+            context: ../../dp-download-service
             dockerfile: Dockerfile.local
         command:
             - reflex
@@ -11,22 +11,20 @@ services:
             - -c
             - ./reflex
         volumes:
-            - ../../dp-cantabular-csv-exporter:/dp-cantabular-csv-exporter
+            - ../../dp-download-service:/dp-download-service
         depends_on:
             - kafka
             - minio
         ports:
-            - 26300:26300
+            - 23600:23600
         environment:
-            BIND_ADDR:              ":26300"
+            BIND_ADDR:              ":23600"
             KAFKA_ADDR:             "kafka:9092"
             DATASET_API_URL:        "http://dp-dataset-api:22000"
-            RECIPE_API_URL:         "http://dp-recipe-api:22300"
-            CANTABULAR_URL:         "http://dp-cantabular-server:8491"
-            CANTABULAR_EXT_API_URL: "http://dp-cantabular-api-ext:8492"
             LOCAL_OBJECT_STORE:     "http://minio:9000"
+            ZEBEDEE_URL:            "http://zebedee:8082"
             MINIO_ACCESS_KEY:       "minio-access-key"
             MINIO_SECRET_KEY:       "minio-secret-key"
             SERVICE_AUTH_TOKEN:     $SERVICE_AUTH_TOKEN
             ENCRYPTION_DISABLED:    "true"
-            UPLOAD_BUCKET_NAME:     "dp-cantabular-csv-exporter"
+            BUCKET_NAME:            "dp-cantabular-csv-exporter"


### PR DESCRIPTION
### What

- Added `dp-download-service.yaml` file and `.env` entry to deploy download service as part of the cantabular import journey docker-compose
- Added ENCRYPTION_DISABLED and UPLOAD_BUCKET_NAME to dp-cantabular-csv-exporter.

### How to review

- Make sure changes make sense
- (note): tested locally with the latest [dp-cantabular-csv-exporter](https://github.com/ONSdigital/dp-cantabular-csv-exporter/pull/24) and [dp-download-service](https://github.com/ONSdigital/dp-download-service/pull/71)

### Who can review

anyone