### PR TITLE
Replaced kafka images for cmd docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,18 +40,24 @@ services:
     ports:
       - 27017:27017
   zookeeper:
-    image: wurstmeister/zookeeper
+    image: 'bitnami/zookeeper:latest'
+    hostname: zookeeper
+    restart: unless-stopped
     ports:
-      - "2181:2181"
-  kafka:
-    image: wurstmeister/kafka:2.11-1.0.2
-    ports:
-      - "9092:9092"
+      - '2181:2181'
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      ALLOW_ANONYMOUS_LOGIN: 'yes'
+  kafka:
+    image: 'bitnami/kafka:latest'
+    hostname: localhost
+    restart: unless-stopped
+    ports:
+      - '9092:9092'
+    environment:
+      KAFKA_BROKER_ID: '1'
+      KAFKA_ADVERTISED_HOST_NAME: 'localhost'
+      KAFKA_ZOOKEEPER_CONNECT: 'zookeeper:2181'
+      ALLOW_PLAINTEXT_LISTENER: 'yes'
     depends_on:
       - zookeeper
   mathjax:


### PR DESCRIPTION
Replaced kafka and zookeepr images for cmd docker-compose: to use `bitnami/kafka:latest` and `bitnami/zookeeper:latest` (same as cantabular import docker-compose). These images are more stable.