### PR TITLE
Fix import api in cantabular-import (legacy kafka addr)

### DIFF
--- a/cantabular-import/dp-import-api.yml
+++ b/cantabular-import/dp-import-api.yml
@@ -21,6 +21,7 @@ services:
         environment:
             MONGODB_IMPORTS_ADDR:     "mongodb:27017"
             KAFKA_ADDR:               "kafka:9092"
+            KAFKA_LEGACY_ADDR:        "kafka:9092"
             ENABLE_PRIVATE_ENDPOINTS: "true"
             RECIPE_API_URL:           "http://dp-recipe-api:22300"
             DATASET_API_URL:          "http://dp-dataset-api:22000"


### PR DESCRIPTION
Override KAFKA_LEGACY_ADDR for import api in cantabular import, so that it works with the legacy kafka (before MSK changes)