### PR TITLE
update to new mongodb_bind_addr var

### DIFF
--- a/cantabular-import/dp-import-api.yml
+++ b/cantabular-import/dp-import-api.yml
@@ -19,7 +19,7 @@ services:
             - 21800:21800
         restart: unless-stopped
         environment:
-            MONGODB_IMPORTS_ADDR:     "mongodb:27017"
+            MONGODB_BIND_ADDR:        "mongodb:27017"
             KAFKA_ADDR:               "kafka:9092"
             KAFKA_LEGACY_ADDR:        "kafka:9092"
             ENABLE_PRIVATE_ENDPOINTS: "true"


### PR DESCRIPTION
# What

Updated an environment variable which has changed for dp-import-api

# How

Run `make start` in `/cantabular-import`, check dp-import-api starts up with no errors (`./logs dp-import-api` in `/cantabular-import`)

# Who

Anyone