### PR TITLE
add vault to cantabular journey

### DIFF
--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -44,3 +44,13 @@ services:
       - MINIO_ACCESS_KEY=minio-access-key
       - MINIO_SECRET_KEY=minio-secret-key
       - MINIO_DEFAULT_BUCKETS=dp-cantabular-csv-exporter,dp-cantabular-metadata-exporter
+  vault:
+    image: 'hashicorp/vault:latest'
+    ports:
+      - '8200:8200'
+    entrypoint: vault server -dev -dev-kv-v1
+    volumes:
+      - ./vault/config:/vault/config
+    environment:
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      - VAULT_DEV_ROOT_TOKEN_ID=0000-0000-0000-0000

--- a/cantabular-import/dp-cantabular-metadata-exporter.yml
+++ b/cantabular-import/dp-cantabular-metadata-exporter.yml
@@ -21,10 +21,12 @@ services:
         environment:
             BIND_ADDR:              ":26700"
             KAFKA_ADDR:             "kafka:9092"
+            VAULT_ADDR:             "http://vault:8200"
             DATASET_API_URL:        "http://dp-dataset-api:22000"
             LOCAL_OBJECT_STORE:     "http://minio:9000"
             MINIO_ACCESS_KEY:       "minio-access-key"
             MINIO_SECRET_KEY:       "minio-secret-key"
             SERVICE_AUTH_TOKEN:     $SERVICE_AUTH_TOKEN
-            ENCRYPTION_DISABLED:    "true"
-            UPLOAD_BUCKET_NAME:     "dp-cantabular-metadata-exporter"
+            VAULT_TOKEN:            "0000-0000-0000-0000"
+            PUBLIC_BUCKET:          "dp-cantabular-metadata-exporter"
+            PRIVATE_BUCKET:         "dp-cantabular-metadata-exporter"


### PR DESCRIPTION
# What

Added Vault to Cantabular journey

# How

In `/cantabular-import`:
run `make start`, check vault container starts with no errors (`./logs vault`)

# Who

Anyone