### PR TITLE
add private bucket for cantabular csv exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ A project to assist in composing multiple DP services
 
 Running dp-compose assumes Docker is running natively and not in a VM. On a Mac this requires Docker for mac - NOT the previous docker toolbox which runs docker in a VM.
 
+Note that if you run Docker using the mac VM, you will need to increase its resources.
+
 https://www.docker.com/products/docker#/mac
 
 Run ```docker-compose up``` to create docker containers for all required backing services. Using the ``` ./run.sh ``` script does the same thing.

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -43,7 +43,7 @@ services:
     environment:
       - MINIO_ACCESS_KEY=minio-access-key
       - MINIO_SECRET_KEY=minio-secret-key
-      - MINIO_DEFAULT_BUCKETS=dp-cantabular-csv-exporter,dp-cantabular-metadata-exporter
+      - MINIO_DEFAULT_BUCKETS=dp-cantabular-csv-private,dp-cantabular-csv-public,dp-cantabular-metadata-exporter
   vault:
     image: 'hashicorp/vault:latest'
     ports:

--- a/cantabular-import/dp-cantabular-csv-exporter.yml
+++ b/cantabular-import/dp-cantabular-csv-exporter.yml
@@ -19,15 +19,16 @@ services:
             - 26300:26300
         restart: unless-stopped
         environment:
-            BIND_ADDR:              ":26300"
-            KAFKA_ADDR:             "kafka:9092"
-            DATASET_API_URL:        "http://dp-dataset-api:22000"
-            RECIPE_API_URL:         "http://dp-recipe-api:22300"
-            CANTABULAR_URL:         "http://dp-cantabular-server:8491"
-            CANTABULAR_EXT_API_URL: "http://dp-cantabular-api-ext:8492"
-            LOCAL_OBJECT_STORE:     "http://minio:9000"
-            MINIO_ACCESS_KEY:       "minio-access-key"
-            MINIO_SECRET_KEY:       "minio-secret-key"
-            SERVICE_AUTH_TOKEN:     $SERVICE_AUTH_TOKEN
-            ENCRYPTION_DISABLED:    "true"
-            UPLOAD_BUCKET_NAME:     "dp-cantabular-csv-exporter"
+            BIND_ADDR:                  ":26300"
+            KAFKA_ADDR:                 "kafka:9092"
+            DATASET_API_URL:            "http://dp-dataset-api:22000"
+            RECIPE_API_URL:             "http://dp-recipe-api:22300"
+            CANTABULAR_URL:             "http://dp-cantabular-server:8491"
+            CANTABULAR_EXT_API_URL:     "http://dp-cantabular-api-ext:8492"
+            LOCAL_OBJECT_STORE:         "http://minio:9000"
+            MINIO_ACCESS_KEY:           "minio-access-key"
+            MINIO_SECRET_KEY:           "minio-secret-key"
+            SERVICE_AUTH_TOKEN:         $SERVICE_AUTH_TOKEN
+            ENCRYPTION_DISABLED:        "true"
+            UPLOAD_BUCKET_NAME:         "dp-cantabular-csv-public"
+            PRIVATE_UPLOAD_BUCKET_NAME: "dp-cantabular-csv-private"


### PR DESCRIPTION
Add private bucket in minio for `cantabular-csv-exporter` and set environment accordingly

Required in order to test [this pr](https://github.com/ONSdigital/dp-cantabular-csv-exporter/pull/42)