### PR TITLE
Replaced cantabular kafka images and map port to localhost

### DIFF
--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -8,25 +8,26 @@ services:
       # Load init script to ensure dbs and collections are created
       - ./mongodb/entrypoint-initdb.d/init.js:/docker-entrypoint-initdb.d/init.js:ro
   zookeeper:
-    image: 'bitnami/zookeeper:latest'
-    hostname: zookeeper
-    restart: unless-stopped
-    ports:
-      - '2181:2181'
+    image: confluentinc/cp-zookeeper:6.0.0
+    expose:
+      - 2181
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
   kafka:
-    image: 'bitnami/kafka:latest'
-    hostname: kafka
-    restart: unless-stopped
+    image: confluentinc/cp-kafka:6.0.0
     ports:
-      - '9092:9092'
-    environment:
-      - KAFKA_BROKER_ID=1
-      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
-      - ALLOW_PLAINTEXT_LISTENER=yes
+      - 19092:19092
     depends_on:
       - zookeeper
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_BROKER_ID: 1
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
   postgres:
     build: ../postgres
     environment: 


### PR DESCRIPTION
### What

- Replaced kafka images used in cantabular docker compose:
  - Using Confluent images, which match the images that are used in the main docker-compose
  - confluent version 6.0.0 uses the same kafka version that is currently being used in develop and production

- Make kafka broker available to localhost:
  - Mapped port `19092` to localhost, so that it can be accessed outside the docker-compose network, from the localhost. (tried to export 9092, but then services failed to communicate with kafka using the docker-compose network)

### How to review

- Run a Cantabular import and validate that services can still communicate via kafka as before
- Try to produce a kafka message from outside the docker network and validate that it is correctly consuemd the the serivce. (e.g. try to run cmd/producer in the csv-exporter service, and validate that the csv exporter service consumes it as expected)

### Who can review

anyone (suggested @redhug1 )