### PR TITLE
create kafka cluster with 3 brokers and fixed addr's and dependencies…

### DIFF
--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       # Load init script to ensure dbs and collections are created
       - ./mongodb/entrypoint-initdb.d/init.js:/docker-entrypoint-initdb.d/init.js:ro
-  zookeeper:
+  zookeeper-1:
     image: confluentinc/cp-zookeeper:6.0.0
     expose:
       - 2181
@@ -15,17 +15,49 @@ services:
       ZOOKEEPER_SERVER_ID: 1
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-  kafka:
+  kafka-1:
     image: confluentinc/cp-kafka:6.0.0
+    expose:
+      - 19092 # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
     ports:
-      - 19092:19092
+      - 9092:9092 # map localhost port so that broker is reachable from the host, values needs to match PLAINTEXT_HOST port
     depends_on:
-      - zookeeper
+      - zookeeper-1
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
       KAFKA_BROKER_ID: 1
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://localhost:19092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:19092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+  kafka-2:
+    image: confluentinc/cp-kafka:6.0.0
+    expose:
+      - 19092 # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
+    ports:
+      - 9093:9093 # map localhost port so that broker is reachable from the host, values needs to match PLAINTEXT_HOST port
+    depends_on:
+      - zookeeper-1
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_BROKER_ID: 2
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:19092,PLAINTEXT_HOST://localhost:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+  kafka-3:
+    image: confluentinc/cp-kafka:6.0.0
+    expose:
+      - 19092 # exposed port to docker network so that the broker is reachable by other brokers, value needs to match PLAINTEXT port
+    ports:
+      - 9094:9094 # map localhost port so that broker is reachable from the host, values needs to match PLAINTEXT_HOST port
+    depends_on:
+      - zookeeper-1
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper-1:2181
+      KAFKA_BROKER_ID: 3
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 2
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:19092,PLAINTEXT_HOST://localhost:9094
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
   postgres:

--- a/cantabular-import/dp-api-router.yml
+++ b/cantabular-import/dp-api-router.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-api-router:/dp-api-router
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - mongodb
         ports:
             - 23200:23200
         restart: unless-stopped
         environment:
             MONGODB_BIND_ADDR:        "mongodb:27017"
-            KAFKA_ADDR:               "kafka:9092"
+            KAFKA_ADDR:               "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             ENABLE_PRIVATE_ENDPOINTS: "true"
             ZEBEDEE_URL:              "http://zebedee:8082"
             RECIPE_API_URL:           "http://dp-recipe-api:22300"

--- a/cantabular-import/dp-cantabular-csv-exporter.yml
+++ b/cantabular-import/dp-cantabular-csv-exporter.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-cantabular-csv-exporter:/dp-cantabular-csv-exporter
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - minio
         ports:
             - 26300:26300
         restart: unless-stopped
         environment:
             BIND_ADDR:                  ":26300"
-            KAFKA_ADDR:                 "kafka:9092"
+            KAFKA_ADDR:                 "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             DATASET_API_URL:            "http://dp-dataset-api:22000"
             RECIPE_API_URL:             "http://dp-recipe-api:22300"
             CANTABULAR_URL:             "http://dp-cantabular-server:8491"

--- a/cantabular-import/dp-cantabular-metadata-exporter.yml
+++ b/cantabular-import/dp-cantabular-metadata-exporter.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-cantabular-metadata-exporter:/dp-cantabular-metadata-exporter
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - minio
         ports:
             - 26700:26700
         restart: unless-stopped
         environment:
             BIND_ADDR:              ":26700"
-            KAFKA_ADDR:             "kafka:9092"
+            KAFKA_ADDR:             "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             VAULT_ADDR:             "http://vault:8200"
             DATASET_API_URL:        "http://dp-dataset-api:22000"
             LOCAL_OBJECT_STORE:     "http://minio:9000"

--- a/cantabular-import/dp-cantabular-xlsx-exporter.yml
+++ b/cantabular-import/dp-cantabular-xlsx-exporter.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-cantabular-xlsx-exporter:/dp-cantabular-xlsx-exporter
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - minio
         ports:
             - 26800:26800
         restart: unless-stopped
         environment:
             BIND_ADDR:                  ":26800"
-            KAFKA_ADDR:                 "kafka:9092"
+            KAFKA_ADDR:                 "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             VAULT_ADDR:                 "http://vault:8200"
             DATASET_API_URL:            "http://dp-dataset-api:22000"
             LOCAL_OBJECT_STORE:         "http://minio:9000"

--- a/cantabular-import/dp-dataset-api.yml
+++ b/cantabular-import/dp-dataset-api.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-dataset-api:/dp-dataset-api
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - mongodb
         ports:
             - 22000:22000
         restart: unless-stopped
         environment:
             MONGODB_BIND_ADDR:             "mongodb:27017"
-            KAFKA_ADDR:                    "kafka:9092"
+            KAFKA_ADDR:                    "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             ENABLE_PRIVATE_ENDPOINTS:      "true"
             ENABLE_DETACH_DATASET:         "true"
             ZEBEDEE_URL:                   "http://zebedee:8082"

--- a/cantabular-import/dp-download-service.yml
+++ b/cantabular-import/dp-download-service.yml
@@ -13,7 +13,9 @@ services:
         volumes:
             - ../../dp-download-service:/dp-download-service
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - minio
             - mongodb
         ports:
@@ -21,7 +23,7 @@ services:
         restart: unless-stopped
         environment:
             BIND_ADDR:              ":23600"
-            KAFKA_ADDR:             "kafka:9092"
+            KAFKA_ADDR:             "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             DATASET_API_URL:        "http://dp-dataset-api:22000"
             LOCAL_OBJECT_STORE:     "http://minio:9000"
             ZEBEDEE_URL:            "http://zebedee:8082"

--- a/cantabular-import/dp-import-api.yml
+++ b/cantabular-import/dp-import-api.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-import-api:/dp-import-api
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - mongodb
         ports:
             - 21800:21800
         restart: unless-stopped
         environment:
             MONGODB_BIND_ADDR:        "mongodb:27017"
-            KAFKA_ADDR:               "kafka:9092"
+            KAFKA_ADDR:               "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             KAFKA_LEGACY_ADDR:        "kafka:9092"
             ENABLE_PRIVATE_ENDPOINTS: "true"
             RECIPE_API_URL:           "http://dp-recipe-api:22300"

--- a/cantabular-import/dp-import-cantabular-dataset.yml
+++ b/cantabular-import/dp-import-cantabular-dataset.yml
@@ -13,13 +13,15 @@ services:
         volumes:
             - ../../dp-import-cantabular-dataset:/dp-import-cantabular-dataset
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
         ports:
             - 26100:26100
         restart: unless-stopped
         environment:
             BIND_ADDR:          ":26100"
-            KAFKA_ADDR:         "kafka:9092"
+            KAFKA_ADDR:         "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             DATASET_API_URL:    "http://dp-dataset-api:22000"
             RECIPE_API_URL:     "http://dp-recipe-api:22300"
             CANTABULAR_URL:     "http://dp-cantabular-server:8491"

--- a/cantabular-import/dp-import-cantabular-dimension-options.yml
+++ b/cantabular-import/dp-import-cantabular-dimension-options.yml
@@ -13,13 +13,15 @@ services:
         volumes:
             - ../../dp-import-cantabular-dimension-options:/dp-import-cantabular-dimension-options
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
         ports:
             - 26200:26200
         restart: unless-stopped
         environment:
             BIND_ADDR:          ":26200"
-            KAFKA_ADDR:         "kafka:9092"
+            KAFKA_ADDR:         "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             DATASET_API_URL:    "http://dp-dataset-api:22000"
             CANTABULAR_URL:     "http://dp-cantabular-server:8491"
             IMPORT_API_URL:     "http://dp-import-api:21800"

--- a/cantabular-import/dp-recipe-api.yml
+++ b/cantabular-import/dp-recipe-api.yml
@@ -13,14 +13,16 @@ services:
         volumes:
             - ../../dp-recipe-api:/dp-recipe-api
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
             - mongodb
         ports:
             - 22300:22300
         restart: unless-stopped
         environment:
             MONGODB_BIND_ADDR:        "mongodb:27017"
-            KAFKA_ADDR:               "kafka:9092"
+            KAFKA_ADDR:               "kafka-1:19092,kafka-2:19092,kafka-3:19092"
             ENABLE_PRIVATE_ENDPOINTS: "true"
             ZEBEDEE_URL:              "http://zebedee:8082"
             SERVICE_AUTH_TOKEN:       $SERVICE_AUTH_TOKEN

--- a/cantabular-import/the-train.yml
+++ b/cantabular-import/the-train.yml
@@ -5,7 +5,9 @@ services:
             context: ../../The-Train
             dockerfile: Dockerfile
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
         ports:
             - 8084:8084
         restart: unless-stopped

--- a/cantabular-import/zebedee.yml
+++ b/cantabular-import/zebedee.yml
@@ -7,7 +7,9 @@ services:
         volumes:
             - ../../dp-recipe-api:/dp-recipe-api
         depends_on:
-            - kafka
+            - kafka-1
+            - kafka-2
+            - kafka-3
         ports:
             - 8082:8082
         volumes:


### PR DESCRIPTION
… accordingly. This is needed after the bugfix to set warning state if enough brokers are running



### What

This PR fixes cantabular docker-compose to work after the changes introduced in dp-dataset-api develop branch (fix for healthcheck, to show `warning` if enough brokers are available)

- Create kafka cluster with 3 brokers for cantabular-import docker compose, which match cmd docker-compose
  - docker network URLs: `kafka-1:19092, kafka-2:19092, kafka-3:19092`
  - localhost ports: `localhost:9092, localhost:9092, localhost:9093`
- Modified all services to use the 3 docker network URLs for kafka brokers
- Modified containers dependencies (`kafka` becomes `kafka-1, kafka-2, kafka-3`)

### How to review

- Make sure changes make sense
- (done it locally already):
  - checkhout latest develop of dp-dataset-api
  - try to run a cantabular import and export, and see that they work with the changes in the PR

### Who can review

anyone