### PR TITLE
Add cantabualr api ext config to cantabular-dimension-options yml file

### DIFF
--- a/cantabular-import/dp-import-cantabular-dataset.yml
+++ b/cantabular-import/dp-import-cantabular-dataset.yml
@@ -20,10 +20,11 @@ services:
             - 26100:26100
         restart: unless-stopped
         environment:
-            BIND_ADDR:          ":26100"
-            KAFKA_ADDR:         "kafka-1:19092,kafka-2:19092,kafka-3:19092"
-            DATASET_API_URL:    "http://dp-dataset-api:22000"
-            RECIPE_API_URL:     "http://dp-recipe-api:22300"
-            CANTABULAR_URL:     "http://dp-cantabular-server:8491"
-            IMPORT_API_URL:     "http://dp-import-api:21800"
-            SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN
+            BIND_ADDR:              ":26100"
+            KAFKA_ADDR:             "kafka-1:19092,kafka-2:19092,kafka-3:19092"
+            DATASET_API_URL:        "http://dp-dataset-api:22000"
+            RECIPE_API_URL:         "http://dp-recipe-api:22300"
+            CANTABULAR_URL:         "http://dp-cantabular-server:8491"
+            CANTABULAR_EXT_API_URL: "http://dp-cantabular-api-ext:8492"
+            IMPORT_API_URL:         "http://dp-import-api:21800"
+            SERVICE_AUTH_TOKEN:     $SERVICE_AUTH_TOKEN

--- a/cantabular-import/dp-import-cantabular-dimension-options.yml
+++ b/cantabular-import/dp-import-cantabular-dimension-options.yml
@@ -20,9 +20,10 @@ services:
             - 26200:26200
         restart: unless-stopped
         environment:
-            BIND_ADDR:          ":26200"
-            KAFKA_ADDR:         "kafka-1:19092,kafka-2:19092,kafka-3:19092"
-            DATASET_API_URL:    "http://dp-dataset-api:22000"
-            CANTABULAR_URL:     "http://dp-cantabular-server:8491"
-            IMPORT_API_URL:     "http://dp-import-api:21800"
-            SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN
+            BIND_ADDR:              ":26200"
+            KAFKA_ADDR:             "kafka-1:19092,kafka-2:19092,kafka-3:19092"
+            DATASET_API_URL:        "http://dp-dataset-api:22000"
+            CANTABULAR_URL:         "http://dp-cantabular-server:8491"
+            CANTABULAR_EXT_API_URL: "http://dp-cantabular-api-ext:8492"
+            IMPORT_API_URL:         "http://dp-import-api:21800"
+            SERVICE_AUTH_TOKEN:     $SERVICE_AUTH_TOKEN


### PR DESCRIPTION
Added `CANTABULAR_EXT_API_URL` to `dp-import-cantabular-dimension-options` and `dp-import-cantabular-dataset`.

Required by the following PRs to be tested locally:
- https://github.com/ONSdigital/dp-import-cantabular-dataset/pull/37
- https://github.com/ONSdigital/dp-import-cantabular-dimension-options/pull/36