### PR TITLE
Add 'skip' flag to skip checking all docker containers are present

### DIFF
--- a/cantabular-import/analysis/full-import-export/README.md
+++ b/cantabular-import/analysis/full-import-export/README.md
@@ -121,7 +121,7 @@ the system tesh script and also take two parameters thus:
 
 ./test-and-logs-by-id.sh 1 skip
 
-which runs the test once and skips cjecking if all the containers have started, which is a situation
+which runs the test once and skips checking if all the containers have started, which is a situation
 that you might deliberately want if you are doing some work with healthcheckers and for example
 you only want 2 of 3 kafka containers running.
 

--- a/cantabular-import/analysis/full-import-export/README.md
+++ b/cantabular-import/analysis/full-import-export/README.md
@@ -112,4 +112,24 @@ All the steps in step 6 can alternatively be achieved by using:
 
 ./test-and-logs-by-id.sh
 
+This also a python script that checks for errors for the import/export job run,
+and checks for DATA RACE in all logs for all containers since they were started.
 
+-=-=-
+
+the system tesh script and also take two parameters thus:
+
+./test-and-logs-by-id.sh 1 skip
+
+which runs the test once and skips cjecking if all the containers have started, which is a situation
+that you might deliberately want if you are doing some work with healthcheckers and for example
+you only want 2 of 3 kafka containers running.
+
+or you might run it as:
+
+./test-and-logs-by-id.sh 15
+
+to run the system test 15 times ... which is typically what is needed to observe DATA RACE's
+as they don't always show up on just one run.
+
+-=-=-

--- a/cantabular-import/analysis/full-import-export/go.mod
+++ b/cantabular-import/analysis/full-import-export/go.mod
@@ -10,7 +10,7 @@ require (
 )
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.6.1
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.7.0
 	github.com/davecgh/go-spew v1.1.1
 )
 

--- a/cantabular-import/analysis/full-import-export/go.sum
+++ b/cantabular-import/analysis/full-import-export/go.sum
@@ -62,8 +62,8 @@ github.com/ONSdigital/dp-api-clients-go v1.28.0/go.mod h1:iyJy6uRL4B6OYOJA0XMr5U
 github.com/ONSdigital/dp-api-clients-go v1.34.3/go.mod h1:kX+YKuoLYLfkeLHMvQKRRydZVxO7ZEYyYiwG2xhV51E=
 github.com/ONSdigital/dp-api-clients-go v1.41.1 h1:xkeT6dCTFSAoBpZxgiJUiuqgcfjCX+c52CIiZo1Y2iU=
 github.com/ONSdigital/dp-api-clients-go v1.41.1/go.mod h1:Ga1+ANjviu21NFJI9wp5NctJIdB4TJLDGbpQFl2V8Wc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.6.1 h1:4Au7WuP/AHTJM75hMXpHJhGahNkwVeN2yCG4SgJZjHQ=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.6.1/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.7.0 h1:1MXb7ihnzY4dqOnNptfll4R890oOocaMJeRd1oI13jw=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.7.0/go.mod h1:oB+Pw1BJlLHUh+a6BJY52VFTRGBEM5RSPlg2Xkq7D9k=
 github.com/ONSdigital/dp-healthcheck v1.0.5/go.mod h1:2wbVAUHMl9+4tWhUlxYUuA1dnf2+NrwzC+So5f5BMLk=
 github.com/ONSdigital/dp-healthcheck v1.1.0/go.mod h1:vZwyjMJiCHjp/sJ2R1ZEqzZT0rJ0+uHVGwxqdP4J5vg=
 github.com/ONSdigital/dp-healthcheck v1.2.1 h1:HL0zHV5FI2Ym31gdMVNW9VLWiEJ0nrwXkVKX1MMPNr4=

--- a/cantabular-import/analysis/full-import-export/main.go
+++ b/cantabular-import/analysis/full-import-export/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"time"
 
@@ -204,18 +205,34 @@ func main() {
 
 	fmt.Printf("Full import and export for Cantabular API's creating private and public (published) files:\n\n")
 
-	count, serviceNames, err := getCantabularContainerCount()
-	if err != nil {
-		fmt.Printf("Error getting container count: %v\n", err)
-		os.Exit(1)
-	}
-	maxContainersInJob := len(requiredServices)
-	if count != maxContainersInJob {
-		fmt.Printf("Incorrect number of Cantabular containers found.\nWanted: %d, found: %d\n... have you started the containers ?\n", maxContainersInJob, count)
-		if count > 0 {
-			listMissingServices(serviceNames)
+	skip := false
+	if len(os.Args) > 1 {
+		param := os.Args[1]
+		if reflect.TypeOf(param).Kind() == reflect.String {
+			param = strings.ToLower(param)
+			if param == "skip" {
+				skip = true
+			}
 		}
-		os.Exit(2)
+	}
+
+	if skip == false {
+		count, serviceNames, err := getCantabularContainerCount()
+		if err != nil {
+			fmt.Printf("Error getting container count: %v\n", err)
+			os.Exit(1)
+		}
+		maxContainersInJob := len(requiredServices)
+		if count != maxContainersInJob {
+			fmt.Printf("Incorrect number of Cantabular containers found.\nWanted: %d, found: %d\n... have you started the containers ?\n", maxContainersInJob, count)
+			if count > 0 {
+				listMissingServices(serviceNames)
+			}
+			os.Exit(2)
+		}
+		fmt.Printf("All %d containers present\n\n", maxContainersInJob)
+	} else {
+		fmt.Printf("    ****  Skipping checking if all containers present  ****\n\n")
 	}
 
 	ensureDirectoryExists(idDir)

--- a/cantabular-import/analysis/test-and-logs-by-id.sh
+++ b/cantabular-import/analysis/test-and-logs-by-id.sh
@@ -8,6 +8,12 @@ if [ -n "$1" ]; then
     N=$1
 fi
 
+SKIP="NO"
+
+if [ -n "$2" ]; then
+    SKIP=$2
+fi
+
 for i in $(seq 1 "$N")
 do
     printf "===================================================================\n\n"
@@ -18,7 +24,7 @@ do
     fi
 
     cd full-import-export
-    go run -race main.go
+    go run -race main.go $SKIP
     cd ..
 
     cd extract-docker-logs


### PR DESCRIPTION
This flag aids with checking healthchecks when one requires one or more of the containers to be not running.