### PR TITLE
add cantabular api ext env var to dp-cantabular-dimension-api

### DIFF
--- a/cantabular-import/dp-cantabular-dimension-api.yml
+++ b/cantabular-import/dp-cantabular-dimension-api.yml
@@ -23,3 +23,4 @@ services:
             ENABLE_PERMISSIONS_AUTH:     "true"
             ZEBEDEE_URL:                 "http://zebedee:8082"
             CANTABULAR_URL:              "http://dp-cantabular-server:8491"
+            CANTABULAR_EXT_API_URL:      "http://dp-cantabular-api-ext:8492"


### PR DESCRIPTION
Added necessary env var to be able to run cantabular dimensions api in dp-compose
[Trello card](https://trello.com/c/tSdkHCF2/5452-get-area-types-implement-endpoint-8)