### PR TITLE
Update CANTABULAR_API_EXT_URL for Dimensions API

### DIFF
--- a/cantabular-import/dp-cantabular-dimension-api.yml
+++ b/cantabular-import/dp-cantabular-dimension-api.yml
@@ -23,4 +23,5 @@ services:
             ENABLE_PERMISSIONS_AUTH:     "true"
             ZEBEDEE_URL:                 "http://zebedee:8082"
             CANTABULAR_URL:              "http://dp-cantabular-server:8491"
-            CANTABULAR_EXT_API_URL:      "http://dp-cantabular-api-ext:8492"
+            CANTABULAR_EXT_API_URL:      "http://dp-cantabular-api-ext:8492" # Legacy, kept for backwards compat with older API versions
+            CANTABULAR_API_EXT_URL:      "http://dp-cantabular-api-ext:8492"


### PR DESCRIPTION
The variable name has changed, meaning newer copies of the Dimensions API won't work with `dp-compose`.

I've kept the old var for the time being so avoid any breakages if people haven't pulled in the latest copy of the API.