### PR TITLE
publishing-dataset-controller port outside docker

### DIFF
--- a/cantabular-import/dp-publishing-dataset-controller.yml
+++ b/cantabular-import/dp-publishing-dataset-controller.yml
@@ -13,7 +13,7 @@ services:
         volumes:
             - ../../dp-publishing-dataset-controller:/dp-publishing-dataset-controller
         ports:
-            - 24000
+          - 24000:24000
         restart: unless-stopped
         environment:
             BIND_ADDR:          ":24000"


### PR DESCRIPTION
PURPOSE
Publish "dp-publishing-dataset-controller" port 24000 outside docker as well so that f/e devs can run florence locally  via make debug to aid development on cantabular-import stack.

CHECK
nc -z -v localhost 24000 should work after docker-compose up in "dp-compose/cantabular-import"

