### PR TITLE
Use up-to-date env vars for minio credentials

### DIFF
--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -74,8 +74,8 @@ services:
     ports:
       - '9001:9000'
     environment:
-      - MINIO_ACCESS_KEY=minio-access-key
-      - MINIO_SECRET_KEY=minio-secret-key
+      - MINIO_ROOT_USER=minio-access-key
+      - MINIO_ROOT_PASSWORD=minio-secret-key
       - MINIO_DEFAULT_BUCKETS=public-bucket,private-bucket
   vault:
     image: 'hashicorp/vault:latest'

--- a/cantabular-import/dp-cantabular-csv-exporter.yml
+++ b/cantabular-import/dp-cantabular-csv-exporter.yml
@@ -34,6 +34,7 @@ services:
             SERVICE_AUTH_TOKEN:         $SERVICE_AUTH_TOKEN
             VAULT_ADDR:                 "http://vault:8200"
             VAULT_TOKEN:                "0000-0000-0000-0000"
-#            ENCRYPTION_DISABLED:        "true"
+            ENCRYPTION_DISABLED:        "true"
             UPLOAD_BUCKET_NAME:         "public-bucket"
             PRIVATE_UPLOAD_BUCKET_NAME: "private-bucket"
+            STOP_CONSUMING_ON_UNHEALTHY: "false"


### PR DESCRIPTION
# What

Update to use ROOT_MINIO_USER and MINIO_ROOT_PASSWORD instead of the deprecated MINIO_ACCESS_KEY and MINIO_SECRET_KEY.

Our services have been having trouble authenticating with minio recently, this change seems to fix it.

# How

Check changes make sense.

To test manually delete your minio container, bring up cantabular import services and check health of dp-cantabular-csv-exporter

# Who

Anyone