### PR TITLE
Add a web UI for monitoring Apache Kafka clusters

### DIFF
--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -214,3 +214,13 @@ not already included in the compose cluster add them to `deps.yml`. Be cognizant
 services the new service is dependant on and add under the `depends_on` clause.
 - Test the new service runs as expected and can be reached by other services and you're
 good to go!
+
+
+# Monitoring Apache Kafka clusters #
+
+On the Docker network we have a couple of Web UIs to monitor our Kafka Cluster on the docker network.
+The tools display information such as brokers, topics, partitions, consumers and lets you view messages
+on our docker network.
+
+* [**Kafdrop**](https://github.com/obsidiandynamics/kafdrop) - [http://localhost:9090](http://localhost:9090)
+* [**Kouncil**](https://docs.kouncil.io/) - [http://localhost:8888](http://localhost:8888)

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -88,3 +88,15 @@ services:
     environment:
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
       - VAULT_DEV_ROOT_TOKEN_ID=0000-0000-0000-0000
+  kafdrop:
+    image: 'obsidiandynamics/kafdrop'
+    restart: "no"
+    ports:
+      - "9090:9000"
+    environment:
+      KAFKA_BROKERCONNECT: "kafka-1:19092"
+      JVM_OPTS: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -100,3 +100,14 @@ services:
       - kafka-1
       - kafka-2
       - kafka-3
+  kouncil:
+    image: consdata/kouncil:latest
+    ports:
+      - '8888:8080'
+    environment:
+      bootstrapServers:
+        kafka-1:19092
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3


### PR DESCRIPTION
Kafdrop is a web UI for monitoring Apache Kafka clusters. The tool
displays information such as brokers, topics, partitions, consumers
(including lag) and lets you view messages on our docker network.
![Screenshot from 2022-05-04 17-52-47](https://user-images.githubusercontent.com/102318/166735522-fff307c8-21b4-44f6-a799-df7568ad840f.png)

