### PR TITLE
Add 'Kowl' as our Kafka monitoring UI tool

### DIFF
--- a/cantabular-import/README.md
+++ b/cantabular-import/README.md
@@ -218,9 +218,8 @@ good to go!
 
 # Monitoring Apache Kafka clusters #
 
-On the Docker network we have a couple of Web UIs to monitor our Kafka Cluster on the docker network.
-The tools display information such as brokers, topics, partitions, consumers and lets you view messages
-on our docker network.
+On the Docker network we have a Kowl as our UI to monitor our Kafka Cluster on the docker network.
+The tools display information such as brokers, topics, partitions, consumers, message schemas and 
+lets you view messages on our docker network.
 
-* [**Kafdrop**](https://github.com/obsidiandynamics/kafdrop) - [http://localhost:9090](http://localhost:9090)
-* [**Kouncil**](https://docs.kouncil.io/) - [http://localhost:8888](http://localhost:8888)
+* [**Kowl**](https://github.com/redpanda-data/kowl) - [http://localhost:9888](http://localhost:9090)

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -110,3 +110,14 @@ services:
       - '9888:8080'
     environment:
       KAFKA_BROKERS: kafka-1:19092,kafka-2:19093,kafka-3:19094
+  kouncil:
+    image: consdata/kouncil:latest
+    ports:
+      - '8888:8080'
+    environment:
+      bootstrapServers:
+        kafka-1:19092
+    depends_on:
+      - kafka-1
+      - kafka-2
+      - kafka-3

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -88,25 +88,12 @@ services:
     environment:
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
       - VAULT_DEV_ROOT_TOKEN_ID=0000-0000-0000-0000
-  kafdrop:
-    image: 'obsidiandynamics/kafdrop'
-    restart: "no"
+  kowl:
+    image: rsmnarts/kowl:latest
     ports:
-      - "9090:9000"
+      - '9888:8080'
     environment:
-      KAFKA_BROKERCONNECT: "kafka-1:19092"
-      JVM_OPTS: "-Xms16M -Xmx48M -Xss180K -XX:-TieredCompilation -XX:+UseStringDeduplication -noverify"
-    depends_on:
-      - kafka-1
-      - kafka-2
-      - kafka-3
-  kouncil:
-    image: consdata/kouncil:latest
-    ports:
-      - '8888:8080'
-    environment:
-      bootstrapServers:
-        kafka-1:19092
+      KAFKA_BROKERS: kafka-1:19092
     depends_on:
       - kafka-1
       - kafka-2

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -30,6 +30,11 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1:19092,PLAINTEXT_HOST://localhost:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9092 || exit -1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
   kafka-2:
     image: confluentinc/cp-kafka:6.0.0
     expose:
@@ -45,6 +50,12 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-2:19092,PLAINTEXT_HOST://localhost:9093
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9093 || exit -1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
+
   kafka-3:
     image: confluentinc/cp-kafka:6.0.0
     expose:
@@ -60,9 +71,14 @@ services:
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-3:19092,PLAINTEXT_HOST://localhost:9094
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+    healthcheck:
+      test: ["CMD-SHELL", "nc -z localhost 9094 || exit -1"]
+      interval: 2s
+      timeout: 2s
+      retries: 15
   postgres:
     build: ../postgres
-    environment: 
+    environment:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=mysecretpassword
     ports:
@@ -89,12 +105,8 @@ services:
       - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
       - VAULT_DEV_ROOT_TOKEN_ID=0000-0000-0000-0000
   kowl:
-    image: rsmnarts/kowl:latest
+    image: quay.io/cloudhut/kowl:master
     ports:
       - '9888:8080'
     environment:
-      KAFKA_BROKERS: kafka-1:19092
-    depends_on:
-      - kafka-1
-      - kafka-2
-      - kafka-3
+      KAFKA_BROKERS: kafka-1:19092,kafka-2:19093,kafka-3:19094

--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -72,8 +72,8 @@ services:
     volumes:
       - ./minio/data:/data
     ports:
-      - '9001:9000'
-      - '9002:9001'
+      - '9000:9000'
+      - '9001:9001'
     environment:
       - MINIO_ROOT_USER=minio-access-key
       - MINIO_ROOT_PASSWORD=minio-secret-key


### PR DESCRIPTION
* [Kowl](https://github.com/redpanda-data/kowl) is a robust Kafka monitoring UI tool and it was recomended by @saminahbab
Also removed the other two Kafka UI tools.


* Also fixed the Minio Console in the local environment to be available on http://localhost:9001