### PR TITLE
Revert minio port mapping, to support Sixteens

### DIFF
--- a/cantabular-import/deps.yml
+++ b/cantabular-import/deps.yml
@@ -88,8 +88,8 @@ services:
     volumes:
       - ./minio/data:/data
     ports:
-      - '9000:9000'
-      - '9001:9001'
+      - '9001:9000'
+      - '9002:9001'
     environment:
       - MINIO_ROOT_USER=minio-access-key
       - MINIO_ROOT_PASSWORD=minio-secret-key


### PR DESCRIPTION
In an attempt to map the same minio ports between the container and the
host machine, inadvertently we have impacted [sixteens](https://github.com/ONSdigital/sixteens) which is ONS' legacy
CSS and JS, as pointed out by @mr-nick17.

A list of local DP compose port allocations:
https://github.com/ONSdigital/dp/blob/main/guides/PORTS.md