### PR TITLE
Fix port number, add pprof port for xlsx-eporter

### DIFF
--- a/cantabular-import/analysis/full-import-export/main.go
+++ b/cantabular-import/analysis/full-import-export/main.go
@@ -59,8 +59,8 @@ var (
 const (
 	idDir             = "../tmp"
 	idFileName        = "../tmp/id.txt"
-	MaxAttempts       = 200 // number of 100ms delays
-	StateVerifyPeriod = 100 // number of milliseconds per period
+	MaxAttempts       = 200  // number of 'period' delays
+	StateVerifyPeriod = 1000 // number of milliseconds per 'period'
 )
 
 var (
@@ -442,7 +442,7 @@ func main() {
 		attempts--
 	}
 	if attempts == 0 {
-		fmt.Printf("failed to see all 4 private files after 20 seconds\nOnly got:\n")
+		fmt.Printf("failed to see all 4 private files after %d seconds\nOnly got:\n", MaxAttempts*StateVerifyPeriod/1000)
 		spew.Dump(instanceFromAPI.Version.Downloads["csv"].Private)
 		spew.Dump(instanceFromAPI.Version.Downloads["csvw"].Private)
 		spew.Dump(instanceFromAPI.Version.Downloads["txt"].Private)
@@ -502,7 +502,7 @@ func main() {
 
 	// then read the instance document again, looking for desired encrypted (private) file creation
 
-	fmt.Printf("\nWaiting for 4 Public files to be created (for upto to 20 seconds):\n")
+	fmt.Printf("\nWaiting for 4 Public files to be created (for upto to %d seconds):\n", MaxAttempts*StateVerifyPeriod/1000)
 	attempts = MaxAttempts
 
 	for attempts > 0 {

--- a/cantabular-import/dp-cantabular-xlsx-exporter.yml
+++ b/cantabular-import/dp-cantabular-xlsx-exporter.yml
@@ -19,6 +19,7 @@ services:
             - minio
         ports:
             - 26800:26800
+            - "6060:6060/tcp"
         restart: unless-stopped
         environment:
             BIND_ADDR:                  ":26800"

--- a/cantabular-import/dp-frontend-filter-flex-dataset.yml
+++ b/cantabular-import/dp-frontend-filter-flex-dataset.yml
@@ -13,7 +13,7 @@ services:
         volumes:
             - ../../dp-frontend-filter-flex-dataset:/dp-frontend-filter-flex-dataset
         ports:
-            - 20200
+            - 20100
         restart: unless-stopped
         environment:
             BIND_ADDR:                ":20100"


### PR DESCRIPTION
Fix frontend-filter-flex-dataset port number.
Add pprof port number to xlsx-exporter.
Increase delays in full-import-export to cope with larger test files.