### PR TITLE
Search stack allow external data

### DIFF
--- a/v2/stacks/README.md
+++ b/v2/stacks/README.md
@@ -242,6 +242,29 @@ make clean
 ```
 
 
+## Search
+
+1) Start the docker stack:
+
+```sh
+make start-detached
+```
+
+2) Stop the docker stack, removing containers, without removing the data:
+
+```sh
+make down
+```
+
+3) You may stop all containers and clean the environment when you finish. WARNING: this will remove local data:
+
+```sh
+make clean
+```
+
+More information in [search stack readme](./search/README.md)
+
+
 ## Static files with auth
 
 1) Start the docker stack

--- a/v2/stacks/search/.env
+++ b/v2/stacks/search/.env
@@ -7,10 +7,12 @@ PATH_MANIFESTS="../../manifests"
 PATH_PROVISIONING="../../provisioning"
 
 # -- Stack config env vars that override manifest defaults --
-# IS_PUBLISHING="false"
+# ZEBEDEE_URL="http://host.docker.internal:8082"       # Uncomment to run backend with mappings
+# DATASET_API_URL="http://host.docker.internal:22000"  # Uncomment to run backent with mappings
 
 # -- Docker compose vars -- 
-COMPOSE_FILE=deps.yml:core-ons.yml
+COMPOSE_FILE=deps.yml:backend.yml:frontend.yml                # Comment to run backend with mappings
+# COMPOSE_FILE=deps.yml:backend-with-mappings.yml:frontend.yml  # Uncomment to run backend with mappings
 COMPOSE_PATH_SEPARATOR=:
 COMPOSE_PROJECT_NAME=search
 COMPOSE_HTTP_TIMEOUT=120

--- a/v2/stacks/search/README.md
+++ b/v2/stacks/search/README.md
@@ -1,0 +1,103 @@
+# Search Stack
+
+This stack deploys the necessary services and dependencies for the search functionality.
+
+The search stack uses elasticsearch to store some indexed data that can be queried via the search api.
+
+You may run the stack in stand-alone mode, assuming you already have the data you need in elasticsearch. 
+
+Or you may run it with mappings to localhost, to obtain data from external sources (required if you need to re-index or run the extract-import pipeline with data available externally)
+
+
+## Run with mappings
+
+If you want to use data from en external source (e.g. Sandbox environment), you may use the backend-with-mappings stack, like so:
+
+1- Set a valid service auth token for the environment you want to use. For example, you may check the environment's secrets in `dp-configs` and use a valid token:
+
+```sh
+export export SERVICE_AUTH_TOKEN=<valid_token>
+```
+
+2- Gain access to the environment you want to use. For example, you may login to sandbox environment:
+
+```sh
+aws sso login --profile dp-sandbox
+```
+
+3- Use the `dp` tool to ssh to `zebedee` and `dp-dataset-api` with port forwarding. For example:
+
+```sh
+# Zebedee
+dp ssh sandbox publishing 1 -p 8082:10.30.138.93:26251
+```
+
+```sh
+# Dataset API
+dp ssh sandbox publishing 2 -p 22000:10.30.138.234:25681
+```
+
+Please, replace the publishing node, ip and port according to where the services are currently deployed when you run this. You can check this in [Consul](https://consul.dp.aws.onsdigital.uk/ui/eu/services)
+
+4- Edit docker-compose config
+
+Edit this stack's `.env` file and uncomment the necessary lines to override `ZEBEDEE_URL` and `DATASET_API_URL` with the `host.docker.internal` values.
+
+Uncomment the `COMPOSE_FILE` that uses `backend-with-mappings.yml` and comment the other one.
+
+5- Run the stack
+
+```sh
+make start-detached
+```
+
+### Reindex
+
+In order to populate elasticsearch, you may run the reindex script, and if you have followed the previous steps you will have access to the necessary external data.
+
+Navigate to your `search-api` location, edit the necessary config under `cmd/reindex/local.go`, and run:
+
+```sh
+make reindex
+```
+
+For more information on the reindex script, please check [search-api instructions](https://github.com/ONSdigital/dp-search-api/blob/develop/README.md#running-bulk-indexer).
+
+### Extract-Import pipeline
+
+When a dataset is published, the search extract-import kafka pipeline is triggered. You may emulate this in the search stack by using the command line tool to generate kafka messages.
+
+WARNING: The pipeline assumes that an index with alias "ons" already exists, please make sure you have run the re-index script before trying the pipeline.
+
+1- Navigate to your `search-data-extractor` location and then to `cmd/producer`
+
+2- Run `go run main.go` and introduce the requested fields. When all the information is introduced a kafka message will be produced. For example:
+
+```sh
+--- [Send Kafka ContentPublished] ---
+Please type the URI
+$ /datasets/your-datasetid-here/editions/2021/versions/1/metadata
+Please type the dataset type (legacy or datasets)
+$ datasets
+Please type the collection ID
+$ collection-id
+{"created_at":"2023-03-28T12:49:39.788994Z","namespace":"dp-search-data-extractor","event":"sending content-published event","severity":3,"data":{"contentPublishedEvent":{"URI":"datasets/your-datasetid-here/editions/2021/versions/1/metadata","DataType":"datasets","CollectionID":"collection-id","JobID":"","SearchIndex":"","TraceID":"054435ded"}}}
+```
+
+3- Check the docker-compose logs, starting with `search-data-extractor` to validate that the message is consumed and processed as expected.
+
+## Run standalone
+
+If you want to run a stand-alone search stack, without external dependencies, you may use the basic stack, like so:
+
+3- Edit docker-compose config
+
+Edit this stack's `.env` file and comment the necessary lines to prevent `ZEBEDEE_URL` and `DATASET_API_URL` being overwritten.
+
+Uncomment the `COMPOSE_FILE` that uses `backend.yml` and comment the other one.
+
+4- Run the stack
+
+```sh
+make start-detached
+```

--- a/v2/stacks/search/backend-with-mappings.yml
+++ b/v2/stacks/search/backend-with-mappings.yml
@@ -1,0 +1,27 @@
+# -- Backend With mappings -- 
+
+# To be used for re-indexing and extract-import pipelines with external data.
+# Contains the search stack backend services without zebedee or dataset api.
+# It assumes that these dependencies will be available in localhost.
+# `extra_hosts` blocks are used to do this mapping.
+
+version: "3.3"
+services:
+  dp-search-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-search-api.yml
+      service: dp-search-api
+  dp-search-data-extractor:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-search-data-extractor.yml
+      service: dp-search-data-extractor
+    extra_hosts:
+      - "host.docker.internal:host-gateway"          # localhost mapping for linux
+      - "docker.for.mac.host.internal:host-gateway"  # localhost mapping for mac (docker v17.12 to v18.02)
+  dp-search-data-importer:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-search-data-importer.yml
+      service: dp-search-data-importer
+    extra_hosts:
+      - "host.docker.internal:host-gateway"          # localhost mapping for linux
+      - "docker.for.mac.host.internal:host-gateway"  # localhost mapping for mac (docker v17.12 to v18.02)

--- a/v2/stacks/search/backend.yml
+++ b/v2/stacks/search/backend.yml
@@ -1,3 +1,8 @@
+# -- Backend -- 
+
+# Contains all the search stack backend services.
+# This is a self-contained stack that doesn't rely on any external mapping or running service
+
 version: "3.3"
 services:
   dp-search-api:

--- a/v2/stacks/search/deps.yml
+++ b/v2/stacks/search/deps.yml
@@ -1,3 +1,7 @@
+# -- Dependencies -- 
+
+# Contains all the search stack non-ons dependencies.
+
 version: "3.3"
 services:
   sitewideelasticsearch:

--- a/v2/stacks/search/frontend.yml
+++ b/v2/stacks/search/frontend.yml
@@ -1,0 +1,6 @@
+# -- Frontend -- 
+
+# Contains all the search stack frontend services.
+# TODO add the necessary services
+
+version: "3.3"


### PR DESCRIPTION
### What

- Separate search stack config files in dependencies, backend and frontend layers.
- Add backend configs for standalone and external dependencies mode
  - Standalone runs the search stack with `dataset-api` and `zebedee`
  - 'with-mappings' runs the search stack `without dataset-api` or `zebedee` but defines the URLs to be external to the docker network
- Add documentation for the search stack, explaining how to run both modes, how to reindex and how to trigger the extract-import pipeline.

### How to review

- Make sure changes make sense
- You may try to run both modes and validate that all services are healthy
- You may try to run a reindex and an extract-import pipeline following the instructions

### Who can review

Anyone