### PR TITLE
feature/add release calendar services to search stack

### DIFF
--- a/v2/manifests/core-ons/dp-api-router.yml
+++ b/v2/manifests/core-ons/dp-api-router.yml
@@ -40,7 +40,7 @@ services:
       FILTER_API_URL:              ${FILTER_API_URL:-http://dp-filter-api:22100}
       TOPIC_API_URL:               ${TOPIC_API_URL:-http://http-echo:5678}
       UPLOAD_SERVICE_API_URL:      ${UPLOAD_API_URL:-http://dp-upload-service:25100}
-      RELEASE_CALENDAR_API_URL:    ${RELEASE_CALENDAR_API_URL:-http://http-echo:5678}
+      RELEASE_CALENDAR_API_URL:    ${RELEASE_CALENDAR_API_URL:-http://dp-release-calendar-api:27800}
       SEARCH_API_URL:              ${SEARCH_API_URL:-http://dp-search-api:23900}
       FILES_API_URL:               ${FILES_API_URL:-http://dp-files-api:26900}
       IDENTITY_API_URL:            ${IDENTITY_API_URL:-http://dp-identity-api:25600}

--- a/v2/manifests/core-ons/dp-frontend-release-calendar.yml
+++ b/v2/manifests/core-ons/dp-frontend-release-calendar.yml
@@ -1,0 +1,30 @@
+version: "3.3"
+services:
+  dp-frontend-release-calendar:
+    build:
+      context: ${ROOT_RELEASE_CALENDAR:-../../../../dp-frontend-release-calendar}
+      dockerfile: Dockerfile.local
+    command:
+      - reflex
+      - -d
+      - none
+      - -c
+      - ./reflex
+    volumes:
+      - ${ROOT_RELEASE_CALENDAR:-../../../../dp-frontend-release-calendar}:/dp-frontend-release-calendar
+    expose:
+      - "27700"
+    ports:
+      - 27700:27700
+    restart: unless-stopped
+    environment:
+      API_ROUTER_URL: ${API_ROUTER_URL:-http://dp-api-router:23200}/v1
+      BABBAGE_URL:    ${BABBAGE_URL:-http://babbage:8080}
+      BIND_ADDR:      ":27700"
+      DEBUG:          ${DEBUG:-false}
+      SITE_DOMAIN:    ${SITE_DOMAIN:-localhost}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:27700/health"]
+      interval:   ${HEALTHCHECK_INTERVAL:-30s}
+      timeout:    10s
+      retries:    10

--- a/v2/manifests/core-ons/dp-frontend-router.yml
+++ b/v2/manifests/core-ons/dp-frontend-router.yml
@@ -28,6 +28,8 @@ services:
       API_ROUTER_URL:                  ${API_ROUTER_URL:-http://dp-api-router:23200}/v1
       FILTER_FLEX_ROUTES_ENABLED:      ${FILTER_FLEX_ROUTES_ENABLED:-false}
       FILTER_FLEX_DATASET_SERVICE_URL: ${FILTER_FLEX_DATASET_SERVICE_URL:-http://dp-frontend-filter-flex-dataset:20100}
+      RELEASE_CALENDAR_ENABLED:        ${RELEASE_CALENDAR_ENABLED:-false}
+      RELEASE_CALENDAR_CONTROLLER_URL: ${RELEASE_CALENDAR_CONTROLLER_URL:-http://dp-frontend-release-calendar:27700}
       SEARCH_ROUTES_ENABLED:           true 
       SEARCH_CONTROLLER_URL:           ${SEARCH_CONTROLLER_URL:-http://dp-frontend-search-controller:25000}
     healthcheck:

--- a/v2/manifests/core-ons/dp-release-calendar-api.yml
+++ b/v2/manifests/core-ons/dp-release-calendar-api.yml
@@ -1,0 +1,27 @@
+version: "3.3"
+services:
+  dp-release-calendar-api:
+    build:
+      context: ${ROOT_RELEASE_CALENDAR_API:-../../../../dp-release-calendar-api}
+      dockerfile: Dockerfile.local
+    command:
+      - reflex
+      - -d
+      - none
+      - -c
+      - ./reflex
+    volumes:
+      - ${ROOT_RELEASE_CALENDAR_API:-../../../../dp-release-calendar-api}:/dp-release-calendar-api
+    expose:
+      - "27800"
+    ports:
+      - 27800:27800
+    restart: unless-stopped
+    environment:
+      BIND_ADDR:                ":27800"
+      API_ROUTER_URL:           ${API_ROUTER_URL:-http://dp-api-router:23200}
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:27800/health" ]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/stacks/search/.env
+++ b/v2/stacks/search/.env
@@ -13,6 +13,7 @@ COMPOSE_HTTP_TIMEOUT=120
 DOCKER_BUILDKIT=0
 
 # -- Stack config env vars that override manifest defaults --
+RELEASE_CALENDAR_ENABLED=true
 
 # -- FULL STACK (WEB) --
 COMPOSE_FILE=deps.yml:backend.yml:frontend.yml
@@ -20,7 +21,7 @@ COMPOSE_FILE=deps.yml:backend.yml:frontend.yml
 # -- BACKEND WITH MAPPINGS -- Uncomment the following lines to run backend with mappings
 #COMPOSE_FILE=deps.yml:backend-with-mappings.yml:frontend.yml
 #ZEBEDEE_URL="http://host.docker.internal:8082"       
-#DATASET_API_URL="http://host.docker.internal:22000" 
+#DATASET_API_URL="http://host.docker.internal:22000"  
 
 # -- FULL STACK (PUBLISHING) -- Uncomment the following lines to run full stack in publishing mode
 #COMPOSE_FILE=deps.yml:backend.yml:frontend.yml:publishing.yml

--- a/v2/stacks/search/README.md
+++ b/v2/stacks/search/README.md
@@ -4,7 +4,7 @@ This stack deploys the necessary services and dependencies for the search functi
 
 The search stack uses elasticsearch to store some indexed data that can be queried via the search api.
 
-You may run the stack in stand-alone mode, assuming you already have the data you need in elasticsearch. 
+You may run the stack in stand-alone mode, assuming you already have the data you need in elasticsearch.
 
 Or you may run it with mappings to localhost, to obtain data from external sources (required if you need to re-index or run the extract-import pipeline with data available externally)
 
@@ -175,3 +175,62 @@ Check the /services directory to ensure there is a token there.
 ```sh
 make start-detached
 ```
+
+### Gotchas
+
+Some errors seen while adding new services that you can overcome
+
+---
+
+`dp-frontend-release-calendar` error 500 on a page similar to <http://localhost:20000/releases/uktotalpublicservicesproductivityestimates2013>. With the logs displaying:
+
+```log
+json: cannot unmarshal string into Go value of type zebedee.HomepageContent
+```
+
+Make sure your Zebedee authentication token is set (old authentication)
+
+- Make a POST request to <http://localhost:8082/login>
+- The body should take the form as:
+
+```json
+{
+    "email": "florence@magicroundabout.ons.gov.uk",
+    "password": "Your local florence/zebedee password"
+}
+```
+
+- Add the response into your browser cookie as a key/value pair `access_token:{ResponseFromPOST}`
+
+---
+
+`dp-frontend-release-calendar` error 503, logs displaying that the app will not run and displaying similar to:
+
+```log
+no such module for github.com/kevinburke/go-bindata/go-bindata 
+run go get github.com/kevinburke/go-bindata/go-bindata
+```
+
+- Delete your local files under the `.go/` (not source controlled) directory for the service
+- Delete the offending image from the container
+- Try again i.e. `make start-detached`
+
+---
+
+GET request to <http://localhost:23200/v1/releases/legacy?url=/releases/uktotalpublicservicesproductivityestimates2013> returning a 500
+
+Solution: set your authentication token
+
+- Make a POST request to <http://localhost:8082/login>
+- The body should take the form as:
+
+```json
+{
+    "email": "florence@magicroundabout.ons.gov.uk",
+    "password": "Your local florence/zebedee password"
+}
+```
+
+- Add the response to the header of the GET request
+
+`X-Florence-Token:{TheResponseFromThePOSTRequest}`

--- a/v2/stacks/search/backend.yml
+++ b/v2/stacks/search/backend.yml
@@ -29,3 +29,7 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-api-router.yml
       service: dp-api-router
+  dp-release-calendar-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-release-calendar-api.yml
+      service: dp-release-calendar-api

--- a/v2/stacks/search/frontend.yml
+++ b/v2/stacks/search/frontend.yml
@@ -4,6 +4,14 @@
 
 version: "3.3"
 services:
+  babbage:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/babbage.yml
+      service: babbage
+  dp-frontend-release-calendar:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-frontend-release-calendar.yml
+      service: dp-frontend-release-calendar
   dp-frontend-search-controller:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-frontend-search-controller.yml


### PR DESCRIPTION
### What

- ✅ [Trello ticket](https://trello.com/c/eojmoqnv/1835-extend-search-docker-stack-with-new-release-calendar-services) - adding necessary config required to add the release calendar to the search stack

### How to review

- Sense check
- _Optionally_ try running the [search stack](https://github.com/ONSdigital/dp-compose/tree/main/v2/stacks/search) using these other PRs/branches:
  - [dp-frontend-release-calendar](https://github.com/ONSdigital/dp-frontend-release-calendar/pull/158)
  - [dp-release-calendar-api](https://github.com/ONSdigital/dp-release-calendar-api/pull/19)

### Who can review

!me
