### PR TITLE
Add rudimentary health targets

### DIFF
--- a/v2/manifests/core-ons/babbage.yml
+++ b/v2/manifests/core-ons/babbage.yml
@@ -28,7 +28,7 @@ services:
       MAP_RENDERER_HOST:        ${MAP_RENDERER_HOST:-http://localhost:23500}
       TABLE_RENDERER_HOST:      ${TABLE_RENDERER_HOST:-http://localhost:23300}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8080/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-api-router.yml
+++ b/v2/manifests/core-ons/dp-api-router.yml
@@ -43,7 +43,7 @@ services:
       FILES_API_URL:               ${FILES_API_URL:-http://dp-files-api:26900}
       IDENTITY_API_URL:            ${IDENTITY_API_URL:-http://dp-identity-api:25600}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:23200/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:23200/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-code-list-api.yml
+++ b/v2/manifests/core-ons/dp-code-list-api.yml
@@ -24,7 +24,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:22400/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:22400/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dataset-api.yml
+++ b/v2/manifests/core-ons/dp-dataset-api.yml
@@ -33,7 +33,7 @@ services:
       MONGODB_BIND_ADDR:           ${MONGODB_BIND_ADDR:-mongodb:27017}
       NEPTUNE_TLS_SKIP_VERIFY:     ${NEPTUNE_TLS_SKIP_VERIFY:-true}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:22000/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:22000/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-design-system.yml
+++ b/v2/manifests/core-ons/dp-design-system.yml
@@ -12,7 +12,7 @@ services:
       - ${ROOT_DESIGN_SYSTEM:-../../../../dp-design-system}:/dp-design-system
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9002" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:9002" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dimension-extractor.yml
+++ b/v2/manifests/core-ons/dp-dimension-extractor.yml
@@ -28,7 +28,7 @@ services:
       VAULT_ADDR:                  ${VAULT_ADDR:-http://vault:8200}
       ZEBEDEE_URL:                 ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:21400/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:21400/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dimension-importer.yml
+++ b/v2/manifests/core-ons/dp-dimension-importer.yml
@@ -31,7 +31,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:21500/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:21500/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dimension-search-builder.yml
+++ b/v2/manifests/core-ons/dp-dimension-search-builder.yml
@@ -29,7 +29,7 @@ services:
       HIERARCHY_API_URL:           ${HIERARCHY_API_URL:-http://dp-hierarchy-api:22600}
       ELASTIC_SEARCH_URL:          ${ELASTIC_SEARCH_URL:-http://cmdelasticsearch:9200}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:22900/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:22900/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-download-service.yml
+++ b/v2/manifests/core-ons/dp-download-service.yml
@@ -1,5 +1,5 @@
-version: '3.3'
-services:  
+version: "3.3"
+services:
   dp-download-service:
     build:
       context: ${ROOT_DOWNLOAD_SERVICE:-../../../../dp-download-service}
@@ -33,7 +33,7 @@ services:
     volumes:
       - ${ROOT_DOWNLOAD_SERVICE:-../../../../dp-download-service}:/service
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:23600/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:23600/health"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-files-api.yml
+++ b/v2/manifests/core-ons/dp-files-api.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 services:
   dp-files-api:
     build:
@@ -35,8 +35,8 @@ services:
     volumes:
       - ${ROOT_FILES_API:-../../../../dp-files-api}:/service
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:26900/health" ]
-      interval: 30s
+      test: ["CMD", "curl", "-sSf", "http://localhost:26900/health"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10
     entrypoint: make debug

--- a/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
@@ -28,7 +28,7 @@ services:
       SERVICE_AUTH_TOKEN:             $SERVICE_AUTH_TOKEN
       SITE_DOMAIN:                    ${SITE_DOMAIN:-localhost}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:20200/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:20200/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-frontend-homepage-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-homepage-controller.yml
@@ -28,7 +28,7 @@ services:
       SERVICE_AUTH_TOKEN:             $SERVICE_AUTH_TOKEN
       SITE_DOMAIN:                    ${SITE_DOMAIN:-localhost}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:24400/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:24400/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-frontend-release-calendar.yml
+++ b/v2/manifests/core-ons/dp-frontend-release-calendar.yml
@@ -24,7 +24,7 @@ services:
       DEBUG:          ${DEBUG:-false}
       SITE_DOMAIN:    ${SITE_DOMAIN:-localhost}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:27700/health"]
-      interval:   ${HEALTHCHECK_INTERVAL:-30s}
-      timeout:    10s
-      retries:    10
+      test: ["CMD", "curl", "-sSf", "http://localhost:27700/health"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/manifests/core-ons/dp-frontend-router.yml
+++ b/v2/manifests/core-ons/dp-frontend-router.yml
@@ -30,7 +30,7 @@ services:
       SEARCH_ROUTES_ENABLED:           true 
       SEARCH_CONTROLLER_URL:           ${SEARCH_CONTROLLER_URL:-http://dp-frontend-search-controller:25000}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:20000/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:20000/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-frontend-search-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-search-controller.yml
@@ -18,12 +18,12 @@ services:
       - 25000:25000
     restart: unless-stopped
     environment:
-      BIND_ADDR:          ":25000"
-      API_ROUTER_URL:     ${API_ROUTER_URL:-http://dp-api-router:23200}/v1
-      IS_PUBLISHING:      ${IS_PUBLISHING:-true}
+      BIND_ADDR: ":25000"
+      API_ROUTER_URL: ${API_ROUTER_URL:-http://dp-api-router:23200}/v1
+      IS_PUBLISHING: ${IS_PUBLISHING:-true}
       SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25000/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25000/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-hierarchy-api.yml
+++ b/v2/manifests/core-ons/dp-hierarchy-api.yml
@@ -30,7 +30,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:24700/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:24700/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-hierarchy-builder.yml
+++ b/v2/manifests/core-ons/dp-hierarchy-builder.yml
@@ -29,7 +29,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:22700/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:22700/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-identity-api.yml
+++ b/v2/manifests/core-ons/dp-identity-api.yml
@@ -35,7 +35,7 @@ services:
       AWS_COGNITO_CLIENT_SECRET:    $AWS_COGNITO_CLIENT_SECRET
       AWS_AUTH_FLOW":               "USER_PASSWORD_AUTH"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25600/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25600/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-image-api.yml
+++ b/v2/manifests/core-ons/dp-image-api.yml
@@ -30,7 +30,7 @@ services:
       ZEBEDEE_URL:                 ${ZEBEDEE_URL:-http://zebedee:8082}
       DOWNLOAD_SERVICE_URL:        ${DOWNLOAD_SERVICE_URL:-http://dp-download-service:23600}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:24700/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:24700/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-image-importer.yml
+++ b/v2/manifests/core-ons/dp-image-importer.yml
@@ -32,7 +32,7 @@ services:
       VAULT_PATH:              "secret/shared/psk"
       DOWNLOAD_SERVICE_URL:    ${DOWNLOAD_SERVICE_URL:-http://dp-download-service:23600}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:24800/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:24800/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-import-api.yml
+++ b/v2/manifests/core-ons/dp-import-api.yml
@@ -28,7 +28,7 @@ services:
       RECIPE_API_URL:              ${RECIPE_API_URL:-http://dp-recipe-api:22300}
       ZEBEDEE_URL:                 ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:21800/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:21800/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-import-tracker.yml
+++ b/v2/manifests/core-ons/dp-import-tracker.yml
@@ -33,7 +33,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:21300/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:21300/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-observation-extractor.yml
+++ b/v2/manifests/core-ons/dp-observation-extractor.yml
@@ -28,7 +28,7 @@ services:
       ZEBEDEE_URL:                 ${ZEBEDEE_URL:-http://zebedee:8082}
       VAULT_ADDR:                  ${VAULT_ADDR:-http://vault:8200}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:21600/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:21600/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-observation-importer.yml
+++ b/v2/manifests/core-ons/dp-observation-importer.yml
@@ -31,7 +31,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:21700/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:21700/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-permissions-api.yml
+++ b/v2/manifests/core-ons/dp-permissions-api.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - ${ROOT_PERMISSIONS_API:-../../../../dp-permissions-api}:/service
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25400/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25400/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-population-types-api.yml
+++ b/v2/manifests/core-ons/dp-population-types-api.yml
@@ -28,7 +28,7 @@ services:
       CANTABULAR_URL:           ${CANTABULAR_URL:-http://localhost:8491}
       CANTABULAR_API_EXT_URL:   ${CANTABULAR_API_EXT_URL:-http://localhost:8492}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:27300/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:27300/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-publishing-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-publishing-dataset-controller.yml
@@ -28,7 +28,7 @@ services:
       SERVICE_AUTH_TOKEN:             $SERVICE_AUTH_TOKEN
       SITE_DOMAIN:                    ${SITE_DOMAIN:-localhost}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:24000/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:24000/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-recipe-api.yml
+++ b/v2/manifests/core-ons/dp-recipe-api.yml
@@ -26,7 +26,7 @@ services:
       IS_PUBLISHING:               ${IS_PUBLISHING:-true}
       ZEBEDEE_URL:                 ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:22300/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:22300/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-release-calendar-api.yml
+++ b/v2/manifests/core-ons/dp-release-calendar-api.yml
@@ -21,7 +21,7 @@ services:
       BIND_ADDR:                ":27800"
       API_ROUTER_URL:           ${API_ROUTER_URL:-http://dp-api-router:23200}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:27800/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:27800/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-search-api.yml
+++ b/v2/manifests/core-ons/dp-search-api.yml
@@ -22,7 +22,7 @@ services:
       ELASTIC_SEARCH_URL: ${ELASTIC_SEARCH_URL:-http://sitewideelasticsearch:9200}
       ZEBEDEE_URL:        ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:23900/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:23900/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-search-data-extractor.yml
+++ b/v2/manifests/core-ons/dp-search-data-extractor.yml
@@ -25,7 +25,7 @@ services:
       DATASET_API_URL:    ${DATASET_API_URL:-http://dp-dataset-api:22000}
       SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25800/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25800/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-search-data-finder.yml
+++ b/v2/manifests/core-ons/dp-search-data-finder.yml
@@ -27,7 +27,7 @@ services:
       SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN
       ZEBEDEE_URL:        ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:28000/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:28000/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-search-data-importer.yml
+++ b/v2/manifests/core-ons/dp-search-data-importer.yml
@@ -24,7 +24,7 @@ services:
       ELASTIC_SEARCH_URL:          ${ELASTIC_SEARCH_URL:-http://sitewideelasticsearch:9200}
       SIGN_ELASTICSEARCH_REQUESTS: ${SIGN_ELASTICSEARCH_REQUESTS:-false}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25900/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25900/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-search-reindex-api.yml
+++ b/v2/manifests/core-ons/dp-search-reindex-api.yml
@@ -27,7 +27,7 @@ services:
       ZEBEDEE_URL:        ${ZEBEDEE_URL:-http://zebedee:8082}
       MONGODB_BIND_ADDR:           ${MONGODB_BIND_ADDR:-mongodb:27017}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25700/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25700/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-search-reindex-tracker.yml
+++ b/v2/manifests/core-ons/dp-search-reindex-tracker.yml
@@ -23,7 +23,7 @@ services:
       SERVICE_AUTH_TOKEN:                 $SERVICE_AUTH_TOKEN
       ZEBEDEE_URL:        ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:28500/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:28500/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 services:
   dp-static-file-publisher:
     build:
@@ -35,7 +35,7 @@ services:
     volumes:
       - ${ROOT_STATIC_FILE_PUBLISHER:-../../../../dp-static-file-publisher}:/service
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:24900/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:24900/health"]
       interval: 30s
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-topic-api.yml
+++ b/v2/manifests/core-ons/dp-topic-api.yml
@@ -22,7 +22,7 @@ services:
       MONGODB_BIND_ADDR: ${MONGODB_BIND_ADDR:-mongodb:27017}
       ZEBEDEE_URL:       ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25300/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25300/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-upload-service.yml
+++ b/v2/manifests/core-ons/dp-upload-service.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 services:
   dp-upload-service:
     build:
@@ -30,7 +30,7 @@ services:
     volumes:
       - ${ROOT_UPLOAD_SERVICE:-../../../../dp-upload-service}:/dp-upload-service
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:25100/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:25100/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/florence.yml
+++ b/v2/manifests/core-ons/florence.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 services:
   florence:
     build:
@@ -27,7 +27,7 @@ services:
       ROUTER_URL:                 ${FRONTEND_ROUTER_URL:-http://dp-frontend-router:20000}
       DATASET_CONTROLLER_URL:     ${DATASET_CONTROLLER_URL:-http://dp-publishing-dataset-controller:24000}
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8081/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:8081/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/sixteens.yml
+++ b/v2/manifests/core-ons/sixteens.yml
@@ -13,7 +13,7 @@ services:
       - /sixteens/node_modules/
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:9000" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:9000"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/zebedee-reader.yml
+++ b/v2/manifests/core-ons/zebedee-reader.yml
@@ -20,7 +20,7 @@ services:
       PACKAGE_PREFIX:    "com.github.onsdigital.zebedee.reader.api"
       zebedee_root:      "/zebedee_root"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8082/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:8082/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/zebedee.yml
+++ b/v2/manifests/core-ons/zebedee.yml
@@ -44,7 +44,7 @@ services:
       website_reindex_key:            "1hZiEDeZcVKZwO6WmTDTDhVSiRAKS0jM6Nzlvlszk0OW0vY5M2FCiGD7ncqcucxB"
       scheduled_publishing_enabled:   "false"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8082/health" ]
+      test: [ "CMD", "curl", "-sSf", "http://localhost:8082/health" ]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/deps/http-echo.yml
+++ b/v2/manifests/deps/http-echo.yml
@@ -1,8 +1,13 @@
-version: '3.3'
-services:  
+version: "3.3"
+services:
   http-echo:
     platform: linux/amd64
     image: hashicorp/http-echo:alpine
-    command: ['-text', 'http-echo']
+    command: ["-text", "http-echo"]
     ports:
       - 15678:5678
+    healthcheck:
+      test: ["CMD", "curl", "-sSf", "http://localhost:5678/"]
+      interval: 60s
+      timeout: 10s
+      retries: 10

--- a/v2/manifests/deps/localstack.yml
+++ b/v2/manifests/deps/localstack.yml
@@ -1,4 +1,4 @@
-version: '3.3'
+version: "3.3"
 services:
   localstack:
     image: localstack/localstack

--- a/v2/manifests/deps/vault.yml
+++ b/v2/manifests/deps/vault.yml
@@ -9,3 +9,8 @@ services:
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: '0000-0000-0000-0000'
       VAULT_DEV_LISTEN_ADDRESS: '0.0.0.0:8200'
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "-O", "-", "http://localhost:8200/v1/sys/health?drsecondarycode=200&performancestandbycode=200&standbycode=200" ]
+      interval: 60s
+      timeout: 10s
+      retries: 10

--- a/v2/scripts/health.sh
+++ b/v2/scripts/health.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+RED="\e[31m"
+AMBER="\e[33m"
+GREEN="\e[32m"
+RESET="\e[0m"
+
+fatal() {
+    printf "${RED}ERROR: %s${RESET}\n" "${1}"
+    exit 1
+}
+
+# ==| MAIN |================================================================
+
+# Ensure jq is installed
+which jq > /dev/null || fatal "jq not installed"
+
+# List services (includes stopped and uninitialised services)
+services=( $(docker-compose config --services) )
+if [[ $? > 0 ]]; then
+    fatal "failed to list services, make sure your compose configuration is valid"
+fi
+
+# Print table header
+printf "  %-40b %-11b %-11b %-40b\n" "NAME" "STATE" "HEALTH" "HEALTH OUTPUT"
+
+# Iterate over services
+for name in ${services[@]}; do
+    error=0
+    warn=0
+    state=""
+    health=""
+    exit_code=""
+    state_f=""
+    health_f=""
+
+    # Get state of service
+    IFS=" " read -r state health exit_code <<<"$(docker-compose ps $name --format=json | jq -r '"\(.State) \(.Health) \(.ExitCode)"')"
+    health_output=""
+
+    # Format the service state
+    if [[ $state == "running"  ]]; then
+        state_f="${GREEN}${state}${RESET}"
+    elif [[ $exit_code > 0 ]]; then
+        state_f="${RED}errored ($exit_code)${RESET}"
+        ((error++))
+    elif [[ -z "$state" ]]; then
+        state_f="${AMBER}stopped${RESET}"
+        ((warn++))
+    else
+        state_f="${RED}${state}${RESET}"
+        ((error++))
+    fi
+
+    # If service is stopped there is no health
+    if [[ -n "$state" ]]; then
+        # Format health of service and get health check output if not healthy and not stopped
+        if [[ $health == "healthy"  ]]; then
+            health_f="${GREEN}${health}${RESET}"
+        else
+            health_output=$(docker inspect $(docker-compose ps -q ${name}) | jq '.[] | .State.Health.Log[-1].Output | @json')
+
+            if [[ $health == "starting" ]]; then
+                health_f="${AMBER}${health}${RESET}"
+                ((warn++))
+            else
+                health_f="${RED}${health}${RESET}"
+                ((error++))
+            fi
+        fi
+    fi
+
+    # Print service row to table
+    if [[ $error > 0 ]]; then
+        printf "${RED}X${RESET} %-40b %-20b %-20b %-40b\n" "$name" "$state_f" "$health_f" "$health_output"
+    elif [[ $warn  > 0 ]]; then
+        printf "${AMBER}-${RESET} %-40b %-20b %-20b %-40b\n" "$name" "$state_f" "$health_f" "$health_output"
+    else
+        printf "${GREEN}✔${RESET} %-40b %-20b %-20b %-40b\n" "$name" "$state_f" "$health_f" "$health_output"
+    fi
+done

--- a/v2/stacks/auth/Makefile
+++ b/v2/stacks/auth/Makefile
@@ -41,3 +41,7 @@ check_defined = \
 __check_defined = \
 	$(if $(value $1),, \
 	$(error Undefined environment variable: $1$(if $2, ($2))))
+
+.PHONY: health
+health:
+	@../../scripts/health.sh

--- a/v2/stacks/cmd/Makefile
+++ b/v2/stacks/cmd/Makefile
@@ -26,3 +26,7 @@ clean:
 .PHONY: install
 install:
 	./install.sh
+
+.PHONY: health
+health:
+	@../../scripts/health.sh

--- a/v2/stacks/homepage-publishing/Makefile
+++ b/v2/stacks/homepage-publishing/Makefile
@@ -22,3 +22,7 @@ down:
 clean:
 	@echo "stopping and removing containers, associated volumes and networks"
 	docker-compose down -v
+
+.PHONY: health
+health:
+	@../../scripts/health.sh

--- a/v2/stacks/homepage-web/Makefile
+++ b/v2/stacks/homepage-web/Makefile
@@ -22,3 +22,7 @@ down:
 clean:
 	@echo "stopping and removing containers, associated volumes and networks"
 	docker-compose down -v
+
+.PHONY: health
+health:
+	@../../scripts/health.sh

--- a/v2/stacks/search/Makefile
+++ b/v2/stacks/search/Makefile
@@ -26,3 +26,7 @@ clean:
 .PHONY: install
 install:
 	./install.sh
+
+.PHONY: health
+health:
+	@../../scripts/health.sh

--- a/v2/stacks/static-files-with-auth/Makefile
+++ b/v2/stacks/static-files-with-auth/Makefile
@@ -22,3 +22,7 @@ down:
 clean:
 	@echo "stopping and removing containers, associated volumes and networks"
 	docker-compose down -v
+
+.PHONY: health
+health:
+	@../../scripts/health.sh

--- a/v2/stacks/static-files/Makefile
+++ b/v2/stacks/static-files/Makefile
@@ -22,3 +22,7 @@ down:
 clean:
 	@echo "stopping and removing containers, associated volumes and networks"
 	docker-compose down -v
+
+.PHONY: health
+health:
+	@../../scripts/health.sh


### PR DESCRIPTION
Add a `health` make target to the stacks that outputs a summary of the stacks health to quickly identify whether it is running. These targets just format the output of the docker health information and therefore work with any docker compose stack.

The output of the curl or wget commands can wrap down multiple lines and make the output messy. While work could be done to truncate these based on the terminal width, this didn't feel essential so instead the curl and wget outputs have been made to be less verbose to limit the ugliness.