### PR TITLE
Add a target to clone all services for stack

### DIFF
--- a/v2/manifests/core-ons/babbage.yml
+++ b/v2/manifests/core-ons/babbage.yml
@@ -1,8 +1,9 @@
 version: '3.3'
 services:
   babbage:
+    x-repo-url: "https://github.com/ONSdigital/babbage"
     build:
-      context: ${ROOT_BABBAGE:-../../../../babbage}
+      context: ${DP_REPO_DIR:-../../../..}/babbage
       dockerfile: Dockerfile.local
     expose:
       - "8080"

--- a/v2/manifests/core-ons/dp-api-router.yml
+++ b/v2/manifests/core-ons/dp-api-router.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-api-router:
+    x-repo-url: "https://github.com/ONSdigital/dp-api-router"
     build:
-      context: ${ROOT_API_ROUTER:-../../../../dp-api-router}
+      context: ${DP_REPO_DIR:-../../../..}/dp-api-router
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_API_ROUTER:-../../../../dp-api-router}:/dp-api-router
+      - ${DP_REPO_DIR:-../../../..}/dp-api-router:/dp-api-router
     expose:
       - "23200"
     ports:
@@ -43,7 +44,7 @@ services:
       FILES_API_URL:               ${FILES_API_URL:-http://dp-files-api:26900}
       IDENTITY_API_URL:            ${IDENTITY_API_URL:-http://dp-identity-api:25600}
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:23200/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:23200/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-code-list-api.yml
+++ b/v2/manifests/core-ons/dp-code-list-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-code-list-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-code-list-api"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-code-list-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-code-list-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-code-list-api}:/dp-code-list-api
+      - ${DP_REPO_DIR:-../../../..}/dp-code-list-api:/dp-code-list-api
     expose:
       - "22400"
     ports:
@@ -24,7 +25,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:22400/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:22400/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dataset-api.yml
+++ b/v2/manifests/core-ons/dp-dataset-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-dataset-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-dataset-api"
     build:
-      context: ${ROOT_DATASET_API:-../../../../dp-dataset-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-dataset-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_DATASET_API:-../../../../dp-dataset-api}:/dp-dataset-api
+      - ${DP_REPO_DIR:-../../../..}/dp-dataset-api:/dp-dataset-api
     expose:
       - "22000"
     ports:
@@ -33,7 +34,7 @@ services:
       MONGODB_BIND_ADDR:           ${MONGODB_BIND_ADDR:-mongodb:27017}
       NEPTUNE_TLS_SKIP_VERIFY:     ${NEPTUNE_TLS_SKIP_VERIFY:-true}
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:22000/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:22000/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-design-system.yml
+++ b/v2/manifests/core-ons/dp-design-system.yml
@@ -1,18 +1,19 @@
 version: "3.3"
 services:
   dp-design-system:
+    x-repo-url: "https://github.com/ONSdigital/dp-design-system"
     build:
-      context: ${ROOT_DESIGN_SYSTEM:-../../../../dp-design-system}
+      context: ${DP_REPO_DIR:-../../../..}/dp-design-system
       dockerfile: Dockerfile.local
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dp-design-system:/dp-design-system
     expose:
       - "9002"
     ports:
       - 9002:9002
-    volumes:
-      - ${ROOT_DESIGN_SYSTEM:-../../../../dp-design-system}:/dp-design-system
     restart: unless-stopped
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:9002" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:9002"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dimension-extractor.yml
+++ b/v2/manifests/core-ons/dp-dimension-extractor.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-dimension-extractor:
+    x-repo-url: "https://github.com/ONSdigital/dp-dimension-extractor"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-dimension-extractor}
+      context: ${DP_REPO_DIR:-../../../..}/dp-dimension-extractor
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-dimension-extractor}:/dp-dimension-extractor
+      - ${DP_REPO_DIR:-../../../..}/dp-dimension-extractor:/dp-dimension-extractor
     expose:
       - "21400"
     ports:
@@ -28,7 +29,7 @@ services:
       VAULT_ADDR:                  ${VAULT_ADDR:-http://vault:8200}
       ZEBEDEE_URL:                 ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:21400/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:21400/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dimension-importer.yml
+++ b/v2/manifests/core-ons/dp-dimension-importer.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-dimension-importer:
+    x-repo-url: "https://github.com/ONSdigital/dp-dimension-importer"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-dimension-importer}
+      context: ${DP_REPO_DIR:-../../../..}/dp-dimension-importer
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-dimension-importer}:/dp-dimension-importer
+      - ${DP_REPO_DIR:-../../../..}/dp-dimension-importer:/dp-dimension-importer
     expose:
       - "21500"
     ports:
@@ -31,7 +32,7 @@ services:
       GRAPH_ADDR:                  ${GRAPH_ADDR:-wss://host.docker.internal:8182/gremlin}
       GRAPH_DRIVER_TYPE:           ${GRAPH_DRIVER_TYPE:-neptune}
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:21500/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:21500/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/manifests/core-ons/dp-dimension-search-builder.yml
+++ b/v2/manifests/core-ons/dp-dimension-search-builder.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-dimension-search-builder:
+    x-repo-url: "https://github.com/ONSdigital/dp-dimension-search-builder"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-dimension-search-builder}
+      context: ${DP_REPO_DIR:-../../../..}/dp-dimension-search-builder
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-dimension-search-builder}:/dp-dimension-search-builder
+      - ${DP_REPO_DIR:-../../../..}/dp-dimension-search-builder:/dp-dimension-search-builder
     expose:
       - "22900"
     ports:

--- a/v2/manifests/core-ons/dp-download-service.yml
+++ b/v2/manifests/core-ons/dp-download-service.yml
@@ -1,37 +1,38 @@
 version: "3.3"
 services:
   dp-download-service:
+    x-repo-url: "https://github.com/ONSdigital/dp-download-service"
     build:
-      context: ${ROOT_DOWNLOAD_SERVICE:-../../../../dp-download-service}
+      context: ${DP_REPO_DIR:-../../../..}/dp-download-service
       dockerfile: Dockerfile.local
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dp-download-service:/dp-download-service
     expose:
       - "23600"
     ports:
       - 23600:23600
     environment:
       HEALTHCHECK_INTERVAL:         ${HEALTHCHECK_INTERVAL:-30s}
-      BIND_ADDR:                    ':23600'
-      AWS_REGION:                   'eu-west-1'
+      BIND_ADDR:                    ":23600"
+      AWS_REGION:                   "eu-west-1"
       LOCALSTACK_HOST:              ${LOCALSTACK_URL:-http://localstack:4566}
-      BUCKET_NAME:                  'testing'
-      PUBLIC_BUCKET_URL:            'http://localhost:4566/testing-public/'
+      BUCKET_NAME:                  "testing"
+      PUBLIC_BUCKET_URL:            "http://localhost:4566/testing-public/"
       ENCRYPTION_DISABLED:          ${ENCRYPTION_DISABLED:-false}
-      GRACEFUL_SHUTDOWN_TIMEOUT:    '5s'
-      HEALTHCHECK_CRITICAL_TIMEOUT: '5s'
-      VAULT_TOKEN:                  '0000-0000-0000-0000'
+      GRACEFUL_SHUTDOWN_TIMEOUT:    "5s"
+      HEALTHCHECK_CRITICAL_TIMEOUT: "5s"
+      VAULT_TOKEN:                  "0000-0000-0000-0000"
       VAULT_ADDR:                   ${VAULT_ADDR:-http://vault:8200}
-      VAULT_PATH:                   'secret/shared/psk'
+      VAULT_PATH:                   "secret/shared/psk"
       FILES_API_URL:                ${FILES_API_URL:-http://dp-files-api:26900}
-      MINIO_ACCESS_KEY:             'test'
-      MINIO_SECRET_KEY:             'test'
+      MINIO_ACCESS_KEY:             "test"
+      MINIO_SECRET_KEY:             "test"
       LOCAL_OBJECT_STORE:           ${LOCALSTACK_URL:-http://localstack:4566}
       IMAGE_API_URL:                ${IMAGE_API_URL:-http://dp-image-api:24700}
       FILTER_API_URL:               ${FILTER_API_URL:-http://dp-filter-api:22100}
       DATASET_API_URL:              ${DATASET_API_URL:-http://dp-dataset-api:22000}
       ZEBEDEE_URL:                  ${ZEBEDEE_URL:-http://zebedee:8082}
-      IS_PUBLISHING:                'true'
-    volumes:
-      - ${ROOT_DOWNLOAD_SERVICE:-../../../../dp-download-service}:/service
+      IS_PUBLISHING:                "true"
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:23600/health"]
       interval: 30s

--- a/v2/manifests/core-ons/dp-files-api.yml
+++ b/v2/manifests/core-ons/dp-files-api.yml
@@ -1,39 +1,40 @@
 version: "3.3"
 services:
   dp-files-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-files-api"
     build:
-      context: ${ROOT_FILES_API:-../../../../dp-files-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-files-api
       dockerfile: Dockerfile-local
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dp-files-api:/dp-files-api
     expose:
       - "26900"
     ports:
       - 26900:26900
     environment:
       HEALTHCHECK_INTERVAL:               ${HEALTHCHECK_INTERVAL:-30s}
-      BIND_ADDR:                          ':26900'
-      GRACEFUL_SHUTDOWN_TIMEOUT:          '30s'
-      HEALTHCHECK_CRITICAL_TIMEOUT:       '30s'
-      KAFKA_ADDR:                         ${KAFKA_ADDR:-kafka:9092}
-      KAFKA_PRODUCER_MIN_BROKERS_HEALTHY: '1'
-      KAFKA_VERSION:                      ${KAFKA_VERSION:-3.1.0}
-      KAFKA_MAX_BYTES:                    '2000000'
-      KAFKA_MIN_HEALTHY_BROKERS:          '1'
-      MONGODB_BIND_ADDR:                  ${MONGODB_BIND_ADDR:-mongodb:27017}
-      MONGODB_DATABASE:                   'files'
-      MONGODB_ENABLE_READ_CONCERN:        'false'
-      MONGODB_ENABLE_WRITE_CONCERN:       'true'
-      MONGODB_CONNECT_TIMEOUT:            '30s'
-      MONGODB_QUERY_TIMEOUT:              '5s'
-      IS_PUBLISHING:                      'true'
+      BIND_ADDR:                          ":26900"
+      GRACEFUL_SHUTDOWN_TIMEOUT:          "30s"
+      HEALTHCHECK_CRITICAL_TIMEOUT:       "30s"
+      KAFKA_ADDR:                         "kafka:9092"
+      KAFKA_PRODUCER_MIN_BROKERS_HEALTHY: "1"
+      KAFKA_VERSION:                      "3.1.0"
+      KAFKA_MAX_BYTES:                    "2000000"
+      KAFKA_MIN_HEALTHY_BROKERS:          "1"
+      MONGODB_BIND_ADDR:                  "mongodb:27017"
+      MONGODB_DATABASE:                   "files"
+      MONGODB_ENABLE_READ_CONCERN:        "false"
+      MONGODB_ENABLE_WRITE_CONCERN:       "true"
+      MONGODB_CONNECT_TIMEOUT:            "30s"
+      MONGODB_QUERY_TIMEOUT:              "5s"
+      IS_PUBLISHING:                      "true"
       PERMISSIONS_API_URL:                ${PERMISSIONS_API_URL:-http://dp-permissions-api:25400}
       IDENTITY_API_URL:                   ${IDENTITY_API_URL:-http://dp-identity-api:25600}
       IDENTITY_WEB_KEY_SET_URL:           ${IDENTITY_API_URL:-http://dp-identity-api:25600}
       ZEBEDEE_URL:                        ${ZEBEDEE_URL:-http://zebedee:8082}
       AUTHORISATION_ENABLED:              ${AUTHORISATION_ENABLED:-true}
-      S3_PRIVATE_BUCKET_NAME:             'testing'
+      S3_PRIVATE_BUCKET_NAME:             "testing"
       LOCALSTACK_HOST:                    ${LOCALSTACK_URL:-http://localstack:4566}
-    volumes:
-      - ${ROOT_FILES_API:-../../../../dp-files-api}:/service
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:26900/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-frontend-dataset-controller:
+    x-repo-url: "https://github.com/ONSdigital/dp-frontend-dataset-controller"
     build:
-      context: ${ROOT_HOMEPAGE_CONTROLLER:-../../../../dp-frontend-dataset-controller}
+      context: ${DP_REPO_DIR:-../../../..}/dp-frontend-dataset-controller
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_HOMEPAGE_CONTROLLER:-../../../../dp-frontend-dataset-controller}:/dp-frontend-dataset-controller
+      - ${DP_REPO_DIR:-../../../..}/dp-frontend-dataset-controller:/dp-frontend-dataset-controller
     expose:
       - "20200"
     ports:

--- a/v2/manifests/core-ons/dp-frontend-homepage-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-homepage-controller.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-frontend-homepage-controller:
+    x-repo-url: "https://github.com/ONSdigital/dp-frontend-homepage-controller"
     build:
-      context: ${ROOT_HOMEPAGE_CONTROLLER:-../../../../dp-frontend-homepage-controller}
+      context: ${DP_REPO_DIR:-../../../..}/dp-frontend-homepage-controller
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_HOMEPAGE_CONTROLLER:-../../../../dp-frontend-homepage-controller}:/dp-frontend-homepage-controller
+      - ${DP_REPO_DIR:-../../../..}/dp-frontend-homepage-controller:/dp-frontend-homepage-controller
     expose:
       - "24400"
     ports:

--- a/v2/manifests/core-ons/dp-frontend-release-calendar.yml
+++ b/v2/manifests/core-ons/dp-frontend-release-calendar.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-frontend-release-calendar:
+    x-repo-url: "https://github.com/ONSdigital/dp-frontend-release-calendar"
     build:
-      context: ${ROOT_RELEASE_CALENDAR:-../../../../dp-frontend-release-calendar}
+      context: ${DP_REPO_DIR:-../../../..}/dp-frontend-release-calendar
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_RELEASE_CALENDAR:-../../../../dp-frontend-release-calendar}:/dp-frontend-release-calendar
+      - ${DP_REPO_DIR:-../../../..}/dp-frontend-release-calendar:/dp-frontend-release-calendar
     expose:
       - "27700"
     ports:

--- a/v2/manifests/core-ons/dp-frontend-router.yml
+++ b/v2/manifests/core-ons/dp-frontend-router.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-frontend-router:
+    x-repo-url: "https://github.com/ONSdigital/dp-frontend-router"
     build:
-      context: ${ROOT_FRONTEND_ROUTER:-../../../../dp-frontend-router}
+      context: ${DP_REPO_DIR:-../../../..}/dp-frontend-router
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_FRONTEND_ROUTER:-../../../../dp-frontend-router}:/dp-frontend-router
+      - ${DP_REPO_DIR:-../../../..}/dp-frontend-router:/dp-frontend-router
     expose:
       - "20000"
     ports:

--- a/v2/manifests/core-ons/dp-frontend-search-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-search-controller.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-frontend-search-controller:
+    x-repo-url: "https://github.com/ONSdigital/dp-frontend-search-controller"
     build:
-      context: ${ROOT_FRONTEND_SEARCH_CONTROLLER:-../../../../dp-frontend-search-controller}
+      context: ${DP_REPO_DIR:-../../../..}/dp-frontend-search-controller
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,16 +12,16 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_FRONTEND_SEARCH_CONTROLLER:-../../../../dp-frontend-search-controller}:/dp-frontend-search-controller
+      - ${DP_REPO_DIR:-../../../..}/dp-frontend-search-controller:/dp-frontend-search-controller
     expose:
       - "25000"
     ports:
       - 25000:25000
     restart: unless-stopped
     environment:
-      BIND_ADDR: ":25000"
-      API_ROUTER_URL: ${API_ROUTER_URL:-http://dp-api-router:23200}/v1
-      IS_PUBLISHING: ${IS_PUBLISHING:-true}
+      BIND_ADDR:          ":25000"
+      API_ROUTER_URL:     ${API_ROUTER_URL:-http://dp-api-router:23200}/v1
+      IS_PUBLISHING:      ${IS_PUBLISHING:-true}
       SERVICE_AUTH_TOKEN: $SERVICE_AUTH_TOKEN
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:25000/health"]

--- a/v2/manifests/core-ons/dp-hierarchy-api.yml
+++ b/v2/manifests/core-ons/dp-hierarchy-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-hierarchy-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-hierarchy-api"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-hierarchy-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-hierarchy-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-hierarchy-api}:/dp-hierarchy-api
+      - ${DP_REPO_DIR:-../../../..}/dp-hierarchy-api:/dp-hierarchy-api
     expose:
       - "22600"
     ports:

--- a/v2/manifests/core-ons/dp-hierarchy-builder.yml
+++ b/v2/manifests/core-ons/dp-hierarchy-builder.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-hierarchy-builder:
+    x-repo-url: "https://github.com/ONSdigital/dp-hierarchy-builder"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-hierarchy-builder}
+      context: ${DP_REPO_DIR:-../../../..}/dp-hierarchy-builder
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-hierarchy-builder}:/dp-hierarchy-builder
+      - ${DP_REPO_DIR:-../../../..}/dp-hierarchy-builder:/dp-hierarchy-builder
     expose:
       - "22700"
     ports:

--- a/v2/manifests/core-ons/dp-identity-api.yml
+++ b/v2/manifests/core-ons/dp-identity-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-identity-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-identity-api"
     build:
-      context: ${ROOT_IDENTITY_API:-../../../../dp-identity-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-identity-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IDENTITY_API:-../../../../dp-identity-api}:/dp-identity-api
+      - ${DP_REPO_DIR:-../../../..}/dp-identity-api:/dp-identity-api
       - ~/.aws/:/root/.aws/
     expose:
       - "25600"

--- a/v2/manifests/core-ons/dp-image-api.yml
+++ b/v2/manifests/core-ons/dp-image-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-image-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-image-api"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-image-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-image-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-image-api}:/dp-image-api
+      - ${DP_REPO_DIR:-../../../..}/dp-image-api:/dp-image-api
     expose:
       - "24700"
     ports:

--- a/v2/manifests/core-ons/dp-image-importer.yml
+++ b/v2/manifests/core-ons/dp-image-importer.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-image-importer:
+    x-repo-url: "https://github.com/ONSdigital/dp-image-importer"
     build:
-      context: ${ROOT_IMAGE_IMPORTER:-../../../../dp-image-importer}
+      context: ${DP_REPO_DIR:-../../../..}/dp-image-importer
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_IMPORTER:-../../../../dp-image-importer}:/dp-image-importer
+      - ${DP_REPO_DIR:-../../../..}/dp-image-importer:/dp-image-importer
     expose:
       - "24800"
     ports:

--- a/v2/manifests/core-ons/dp-import-api.yml
+++ b/v2/manifests/core-ons/dp-import-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-import-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-import-api"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-import-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-import-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-import-api}:/dp-import-api
+      - ${DP_REPO_DIR:-../../../..}/dp-import-api:/dp-import-api
     expose:
       - "21800"
     ports:

--- a/v2/manifests/core-ons/dp-import-tracker.yml
+++ b/v2/manifests/core-ons/dp-import-tracker.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-import-tracker:
+    x-repo-url: "https://github.com/ONSdigital/dp-import-tracker"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-import-tracker}
+      context: ${DP_REPO_DIR:-../../../..}/dp-import-tracker
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-import-tracker}:/dp-import-tracker
+      - ${DP_REPO_DIR:-../../../..}/dp-import-tracker:/dp-import-tracker
     expose:
       - "21300"
     ports:

--- a/v2/manifests/core-ons/dp-observation-extractor.yml
+++ b/v2/manifests/core-ons/dp-observation-extractor.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-observation-extractor:
+    x-repo-url: "https://github.com/ONSdigital/dp-observation-extractor"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-observation-extractor}
+      context: ${DP_REPO_DIR:-../../../..}/dp-observation-extractor
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-observation-extractor}:/dp-observation-extractor
+      - ${DP_REPO_DIR:-../../../..}/dp-observation-extractor:/dp-observation-extractor
     expose:
       - "21600"
     ports:

--- a/v2/manifests/core-ons/dp-observation-importer.yml
+++ b/v2/manifests/core-ons/dp-observation-importer.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-observation-importer:
+    x-repo-url: "https://github.com/ONSdigital/dp-observation-importer"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-observation-importer}
+      context: ${DP_REPO_DIR:-../../../..}/dp-observation-importer
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-observation-importer}:/dp-observation-importer
+      - ${DP_REPO_DIR:-../../../..}/dp-observation-importer:/dp-observation-importer
     expose:
       - "21700"
     ports:

--- a/v2/manifests/core-ons/dp-permissions-api.yml
+++ b/v2/manifests/core-ons/dp-permissions-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-permissions-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-permissions-api"
     build:
-      context: ${ROOT_PERMISSIONS_API:-../../../../dp-permissions-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-permissions-api
       dockerfile: Dockerfile-local
     expose:
       - "25400"
@@ -20,7 +21,7 @@ services:
       IS_PUBLISHING:                ${IS_PUBLISHING:-true}
       IDENTITY_WEB_KEY_SET_URL:     ${IDENTITY_API_URL:-http://dp-identity-api:25600}
     volumes:
-      - ${ROOT_PERMISSIONS_API:-../../../../dp-permissions-api}:/service
+      - ${DP_REPO_DIR:-../../../..}/dp-permissions-api:/service
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:25400/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/manifests/core-ons/dp-population-types-api.yml
+++ b/v2/manifests/core-ons/dp-population-types-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-population-types-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-population-types-api"
     build:
-      context: ${ROOT_POPULATION_TYPES_API:-../../../../dp-population-types-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-population-types-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_POPULATION_TYPES_API:-../../../../dp-population-types-api}:/dp-population-types-api
+      - ${DP_REPO_DIR:-../../../..}/dp-population-types-api:/dp-population-types-api
     expose:
       - "27300"
     ports:

--- a/v2/manifests/core-ons/dp-publishing-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-publishing-dataset-controller.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-publishing-dataset-controller:
+    x-repo-url: "https://github.com/ONSdigital/dp-publishing-dataset-controller"
     build:
-      context: ${ROOT_HOMEPAGE_CONTROLLER:-../../../../dp-publishing-dataset-controller}
+      context: ${DP_REPO_DIR:-../../../..}/dp-publishing-dataset-controller
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_HOMEPAGE_CONTROLLER:-../../../../dp-publishing-dataset-controller}:/dp-publishing-dataset-controller
+      - ${DP_REPO_DIR:-../../../..}/dp-publishing-dataset-controller:/dp-publishing-dataset-controller
     expose:
       - "24000"
     ports:

--- a/v2/manifests/core-ons/dp-recipe-api.yml
+++ b/v2/manifests/core-ons/dp-recipe-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-recipe-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-recipe-api"
     build:
-      context: ${ROOT_IMAGE_API:-../../../../dp-recipe-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-recipe-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_IMAGE_API:-../../../../dp-recipe-api}:/dp-recipe-api
+      - ${DP_REPO_DIR:-../../../..}/dp-recipe-api:/dp-recipe-api
     expose:
       - "22300"
     ports:

--- a/v2/manifests/core-ons/dp-release-calendar-api.yml
+++ b/v2/manifests/core-ons/dp-release-calendar-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-release-calendar-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-release-calendar-api"
     build:
-      context: ${ROOT_RELEASE_CALENDAR_API:-../../../../dp-release-calendar-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-release-calendar-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_RELEASE_CALENDAR_API:-../../../../dp-release-calendar-api}:/dp-release-calendar-api
+      - ${DP_REPO_DIR:-../../../..}/dp-release-calendar-api:/dp-release-calendar-api
     expose:
       - "27800"
     ports:

--- a/v2/manifests/core-ons/dp-search-api.yml
+++ b/v2/manifests/core-ons/dp-search-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-search-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-search-api"
     build:
-      context: ${ROOT_SEARCH_API:-../../../../dp-search-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-search-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_SEARCH_API:-../../../../dp-search-api}:/dp-search-api
+      - ${DP_REPO_DIR:-../../../..}/dp-search-api:/dp-search-api
     expose:
       - "23900"
     ports:

--- a/v2/manifests/core-ons/dp-search-data-extractor.yml
+++ b/v2/manifests/core-ons/dp-search-data-extractor.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-search-data-extractor:
+    x-repo-url: "https://github.com/ONSdigital/dp-search-data-extractor"
     build:
-      context: ${ROOT_SEARCH_DATA_EXTRACTOR:-../../../../dp-search-data-extractor}
+      context: ${DP_REPO_DIR:-../../../..}/dp-search-data-extractor
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_SEARCH_DATA_EXTRACTOR:-../../../../dp-search-data-extractor}:/dp-search-data-extractor
+      - ${DP_REPO_DIR:-../../../..}/dp-search-data-extractor:/dp-search-data-extractor
     expose:
       - "25800"
     ports:

--- a/v2/manifests/core-ons/dp-search-data-finder.yml
+++ b/v2/manifests/core-ons/dp-search-data-finder.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-search-data-finder:
+    x-repo-url: "https://github.com/ONSdigital/dp-search-data-finder"
     build:
-      context: ${ROOT_SEARCH_DATA_FINDER:-../../../../dp-search-data-finder}
+      context: ${DP_REPO_DIR:-../../../..}/dp-search-data-finder
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_SEARCH_DATA_FINDER:-../../../../dp-search-data-finder}:/dp-search-data-finder
+      - ${DP_REPO_DIR:-../../../..}/dp-search-data-finder:/dp-search-data-finder
     expose:
       - "28000"
     ports:

--- a/v2/manifests/core-ons/dp-search-data-importer.yml
+++ b/v2/manifests/core-ons/dp-search-data-importer.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-search-data-importer:
+    x-repo-url: "https://github.com/ONSdigital/dp-search-data-importer"
     build:
-      context: ${ROOT_SEARCH_DATA_IMPORTER:-../../../../dp-search-data-importer}
+      context: ${DP_REPO_DIR:-../../../..}/dp-search-data-importer
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_SEARCH_DATA_IMPORTER:-../../../../dp-search-data-importer}:/dp-search-data-importer
+      - ${DP_REPO_DIR:-../../../..}/dp-search-data-importer:/dp-search-data-importer
     expose:
       - "25900"
     ports:

--- a/v2/manifests/core-ons/dp-search-reindex-api.yml
+++ b/v2/manifests/core-ons/dp-search-reindex-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-search-reindex-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-search-reindex-api"
     build:
-      context: ${ROOT_SEARCH_REINDEX_API:-../../../../dp-search-reindex-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-search-reindex-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_SEARCH_REINDEX_API:-../../../../dp-search-reindex-api}:/dp-search-reindex-api
+      - ${DP_REPO_DIR:-../../../..}/dp-search-reindex-api:/dp-search-reindex-api
     expose:
       - "25700"
     ports:
@@ -22,10 +23,10 @@ services:
       ELASTIC_SEARCH_URL: ${ELASTIC_SEARCH_URL:-http://sitewideelasticsearch:9200}
       KAFKA_ADDR:         ${KAFKA_ADDR:-kafka-1:19092,kafka-2:19092,kafka-3:19092}
       KAFKA_VERSION:      ${KAFKA_VERSION:-3.1.0}
-      SEARCH_API_URL: ${SEARCH_API_URL:-http://dp-search-api:23900}
-      SERVICE_AUTH_TOKEN:                 $SERVICE_AUTH_TOKEN
+      SEARCH_API_URL:     ${SEARCH_API_URL:-http://dp-search-api:23900}
+      SERVICE_AUTH_TOKEN: ${SERVICE_AUTH_TOKEN}
       ZEBEDEE_URL:        ${ZEBEDEE_URL:-http://zebedee:8082}
-      MONGODB_BIND_ADDR:           ${MONGODB_BIND_ADDR:-mongodb:27017}
+      MONGODB_BIND_ADDR:  ${MONGODB_BIND_ADDR:-mongodb:27017}
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:25700/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/manifests/core-ons/dp-search-reindex-tracker.yml
+++ b/v2/manifests/core-ons/dp-search-reindex-tracker.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-search-reindex-tracker:
+    x-repo-url: "https://github.com/ONSdigital/dp-search-reindex-tracker"
     build:
-      context: ${ROOT_SEARCH_REINDEX_TRACKER:-../../../../dp-search-reindex-tracker}
+      context: ${DP_REPO_DIR:-../../../..}/dp-search-reindex-tracker
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_SEARCH_REINDEX_TRACKER:-../../../../dp-search-reindex-racker}:/dp-search-reindex-tracker
+      - ${DP_REPO_DIR:-../../../..}/dp-search-reindex-tracker:/dp-search-reindex-tracker
     expose:
       - "28500"
     ports:
@@ -20,7 +21,7 @@ services:
     environment:
       BIND_ADDR:          ":28500"
       ELASTIC_SEARCH_URL: ${ELASTIC_SEARCH_URL:-http://sitewideelasticsearch:9200}
-      SERVICE_AUTH_TOKEN:                 $SERVICE_AUTH_TOKEN
+      SERVICE_AUTH_TOKEN: ${SERVICE_AUTH_TOKEN}
       ZEBEDEE_URL:        ${ZEBEDEE_URL:-http://zebedee:8082}
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:28500/health"]

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -1,39 +1,43 @@
 version: "3.3"
 services:
   dp-static-file-publisher:
+    x-repo-url: "https://github.com/ONSdigital/dp-static-file-publisher"
     build:
-      context: ${ROOT_STATIC_FILE_PUBLISHER:-../../../../dp-static-file-publisher}
+      context: ${DP_REPO_DIR:-../../../..}/dp-static-file-publisher
       dockerfile: Dockerfile-local
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dp-static-file-publisher:/dp-static-file-publisher
     expose:
       - "24900"
     ports:
       - 24900:24900
     environment:
       HEALTHCHECK_INTERVAL:               ${HEALTHCHECK_INTERVAL:-30s}
-      BIND_ADDR:                          ':24900'
-      GRACEFUL_SHUTDOWN_TIMEOUT:          '30s'
-      HEALTHCHECK_CRITICAL_TIMEOUT:       '30s'
-      VAULT_TOKEN:                        '0000-0000-0000-0000'
+      BIND_ADDR:                          ":24900"
+      GRACEFUL_SHUTDOWN_TIMEOUT:          "30s"
+      HEALTHCHECK_CRITICAL_TIMEOUT:       "30s"
+      VAULT_TOKEN:                        "0000-0000-0000-0000"
       VAULT_ADDR:                         ${VAULT_ADDR:-http://vault:8200}
-      VAULT_PATH:                         'secret/shared/psk'
-      VAULT_RETRIES:                      '3'
-      KAFKA_ADDR:                         'kafka:9092'
-      KAFKA_PRODUCER_MIN_BROKERS_HEALTHY: '1'
-      KAFKA_VERSION:                      '3.1.0'
-      KAFKA_MAX_BYTES:                    '2000000'
-      KAFKA_MIN_HEALTHY_BROKERS:          '1'
-      STATIC_FILE_PUBLISHED_TOPIC:        'static-file-published'
-      STATIC_FILE_PUBLISHED_TOPIC_V2:     'static-file-published-v2'
-      S3_PRIVATE_BUCKET_NAME:             'testing'
-      S3_PUBLIC_BUCKET_NAME:              'testing-public'
+      VAULT_PATH:                         "secret/shared/psk"
+      VAULT_RETRIES:                      "3"
+      KAFKA_ADDR:                         "kafka:9092"
+      KAFKA_PRODUCER_MIN_BROKERS_HEALTHY: "1"
+      KAFKA_VERSION:                      "3.1.0"
+      KAFKA_MAX_BYTES:                    "2000000"
+      KAFKA_MIN_HEALTHY_BROKERS:          "1"
+      STATIC_FILE_PUBLISHED_TOPIC:        "static-file-published"
+      STATIC_FILE_PUBLISHED_TOPIC_V2:     "static-file-published-v2"
+      AWS_REGION:                         "eu-west-1"
+      AWS_SECRET_ACCESS_KEY:              "test"
+      AWS_ACCESS_KEY_ID:                  "test"
+      S3_PRIVATE_BUCKET_NAME:             "testing"
+      S3_PUBLIC_BUCKET_NAME:              "testing-public"
       FILES_API_URL:                      ${FILES_API_URL:-http://dp-files-api:26900}
-      CONSUMER_GROUP:                     'dp-static-file-publisher'
+      CONSUMER_GROUP:                     "dp-static-file-publisher"
       S3_LOCAL_URL:                       ${LOCALSTACK_URL:-http://localstack:4566}
-      S3_LOCAL_ID:                        'test'
-      S3_LOCAL_SECRET:                    'test'
+      S3_LOCAL_ID:                        "test"
+      S3_LOCAL_SECRET:                    "test"
       IMAGE_API_URL:                      ${IMAGE_API_URL:-http://dp-image-api:24700}
-    volumes:
-      - ${ROOT_STATIC_FILE_PUBLISHER:-../../../../dp-static-file-publisher}:/service
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:24900/health"]
       interval: 30s

--- a/v2/manifests/core-ons/dp-topic-api.yml
+++ b/v2/manifests/core-ons/dp-topic-api.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-topic-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-topic-api"
     build:
-      context: ${ROOT_TOPIC_API:-../../../../dp-topic-api}
+      context: ${DP_REPO_DIR:-../../../..}/dp-topic-api
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_TOPIC_API:-../../../../dp-topic-api}:/dp-topic-api
+      - ${DP_REPO_DIR:-../../../..}/dp-topic-api:/dp-topic-api
     expose:
       - "25300"
     ports:

--- a/v2/manifests/core-ons/dp-upload-service.yml
+++ b/v2/manifests/core-ons/dp-upload-service.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   dp-upload-service:
+    x-repo-url: "https://github.com/ONSdigital/dp-upload-service"
     build:
-      context: ${ROOT_UPLOAD_SERVICE:-../../../../dp-upload-service}
+      context: ${DP_REPO_DIR:-../../../..}/dp-upload-service
       dockerfile: Dockerfile-local
     command:
       - reflex
@@ -10,25 +11,27 @@ services:
       - none
       - -c
       - ./reflex
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dp-upload-service:/dp-upload-service
+    expose:
+      - "25100"
     ports:
       - 25100:25100
     environment:
       HEALTHCHECK_INTERVAL:               ${HEALTHCHECK_INTERVAL:-30s}
-      BIND_ADDR:                          ':25100'
-      AWS_REGION:                         'eu-west-1'
+      BIND_ADDR:                          ":25100"
+      AWS_REGION:                         "eu-west-1"
       LOCALSTACK_HOST:                    ${LOCALSTACK_URL:-http://localstack:4566}
-      UPLOAD_BUCKET_NAME:                 'deprecated'
-      STATIC_FILES_ENCRYPTED_BUCKET_NAME: 'testing'
+      UPLOAD_BUCKET_NAME:                 "deprecated"
+      STATIC_FILES_ENCRYPTED_BUCKET_NAME: "testing"
       ENCRYPTION_DISABLED:                ${ENCRYPTION_DISABLED:-false}
-      GRACEFUL_SHUTDOWN_TIMEOUT:          '5s'
-      HEALTHCHECK_CRITICAL_TIMEOUT:       '5s'
-      VAULT_TOKEN:                        '0000-0000-0000-0000'
-      VAULT_ADDR:                         ${VAULT_ADDR:-http://vault:8200}
-      VAULT_PATH:                         'secret/shared/psk'
+      GRACEFUL_SHUTDOWN_TIMEOUT:          "5s"
+      HEALTHCHECK_CRITICAL_TIMEOUT:       "5s"
+      VAULT_TOKEN:                        "0000-0000-0000-0000"
+      VAULT_ADDR:                         "http://vault:8200"
+      VAULT_PATH':                        "secret/shared/psk"
       FILES_API_URL:                      ${FILES_API_URL:-http://dp-files-api:26900}
       SERVICE_AUTH_TOKEN:                 $SERVICE_AUTH_TOKEN
-    volumes:
-      - ${ROOT_UPLOAD_SERVICE:-../../../../dp-upload-service}:/dp-upload-service
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:25100/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/manifests/core-ons/florence.yml
+++ b/v2/manifests/core-ons/florence.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   florence:
+    x-repo-url: "https://github.com/ONSdigital/florence"
     build:
-      context: ${ROOT_FLORENCE:-../../../../florence}
+      context: ${DP_REPO_DIR:-../../../..}/florence
       dockerfile: Dockerfile.local
     command:
       - reflex
@@ -11,7 +12,7 @@ services:
       - -c
       - ./reflex
     volumes:
-      - ${ROOT_FLORENCE:-../../../../florence}:/florence
+      - ${DP_REPO_DIR:-../../../..}/florence:/florence
     expose:
       - "8081"
     ports:

--- a/v2/manifests/core-ons/sixteens.yml
+++ b/v2/manifests/core-ons/sixteens.yml
@@ -1,16 +1,16 @@
 version: "3.3"
 services:
   sixteens:
+    x-repo-url: "https://github.com/ONSdigital/sixteens"
     build:
-      context: ${ROOT_SIXTEENS:-../../../../sixteens}
+      context: ${DP_REPO_DIR:-../../../..}/sixteens
       dockerfile: Dockerfile.local
     expose:
       - "9000"
     ports:
       - 9000:9000
     volumes:
-      - ${ROOT_SIXTEENS:-../../../../sixteens}:/sixteens
-      - /sixteens/node_modules/
+      - ${DP_REPO_DIR:-../../../..}/sixteens:/sixteens
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:9000"]

--- a/v2/manifests/core-ons/the-train.yml
+++ b/v2/manifests/core-ons/the-train.yml
@@ -1,8 +1,9 @@
-version: '3.3'
+version: "3.3"
 services:
   the-train:
+    x-repo-url: "https://github.com/ONSdigital/the-train"
     build:
-      context: ${ROOT_THE_TRAIN:-../../../../The-Train}
+      context: ${DP_REPO_DIR:-../../../..}/the-train
       dockerfile: Dockerfile
     expose:
       - "8084"
@@ -19,7 +20,6 @@ services:
       PORT:                        8084
       DP_COLOURED_LOGGING:         "true"
       DP_LOGGING_FORMAT:           "pretty_json"
-      PUBLISHING_THREAD_POOL_SIZE: 100
       MAX_FILE_UPLOAD_SIZE_MB:     -1
       MAX_REQUEST_SIZE_MB:         -1
       FILE_THRESHOLD_SIZE_MB:      0

--- a/v2/manifests/core-ons/zebedee-reader.yml
+++ b/v2/manifests/core-ons/zebedee-reader.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
-  zebedee:
+  zebedee-reader:
+    x-repo-url: "https://github.com/ONSdigital/zebedee"
     build:
-      context: ${ROOT_ZEBEDEE:-../../../../zebedee}/zebedee-reader
+      context: ${DP_REPO_DIR:-../../../..}/zebedee/zebedee-reader
       dockerfile: Dockerfile.local
     expose:
       - "8082"

--- a/v2/manifests/core-ons/zebedee.yml
+++ b/v2/manifests/core-ons/zebedee.yml
@@ -1,8 +1,9 @@
 version: "3.3"
 services:
   zebedee:
+    x-repo-url: "https://github.com/ONSdigital/zebedee"
     build:
-      context: ${ROOT_ZEBEDEE:-../../../../zebedee}
+      context: ${DP_REPO_DIR:-../../../..}/zebedee
       dockerfile: Dockerfile
     expose:
       - "8082"
@@ -44,7 +45,7 @@ services:
       website_reindex_key:            "1hZiEDeZcVKZwO6WmTDTDhVSiRAKS0jM6Nzlvlszk0OW0vY5M2FCiGD7ncqcucxB"
       scheduled_publishing_enabled:   "false"
     healthcheck:
-      test: [ "CMD", "curl", "-sSf", "http://localhost:8082/health" ]
+      test: ["CMD", "curl", "-sSf", "http://localhost:8082/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}
       timeout: 10s
       retries: 10

--- a/v2/scripts/clone.sh
+++ b/v2/scripts/clone.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Set DP_REPO_DIR to override the default repo cloning location
+DP_COMPOSE_V2_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+DP_REPO_DIR=${DP_REPO_DIR:-${DP_COMPOSE_V2_DIR}/../..}
+
+# Set VERBOSE=true to debug connection issues
+VERBOSE=${VERBOSE:-false}
+
+#==| CONSTANTS |================================================
+RED="\e[31m"
+AMBER="\e[33m"
+GREEN="\e[32m"
+RESET="\e[0m"
+REPO_URL_REGEX='^https?:\/\/[^\/]+\/([^\/]+)\/([^\/]+)\/?$'
+
+#==| FUNCTIONS |================================================
+
+# Fatal error log that exits the script with error code 1
+fatal() {
+    echo -e "${RED}ERROR: ${1}${RESET}"
+    exit 1
+}
+
+# Red error log
+error() {
+    echo -e "${RED}ERROR: ${1}${RESET}"
+}
+
+# Green info log
+info() {
+    echo -e "${GREEN}INFO: ${1}${RESET}"
+}
+
+# ==| MAIN |================================================================
+
+# Ensure dependencies are installed
+[[ -n $BASH_VERSINFO && $BASH_VERSINFO -lt 4 ]] && fatal "your 'bash' is too old, please run 'brew install bash'"
+which git > /dev/null || fatal "git not installed"
+which yq > /dev/null || fatal "yq not installed"
+
+# Test ssh to github
+if [[ $VERBOSE = true ]]; then
+    ssh -v -T git@github.com
+else
+    ssh -T git@github.com &>/dev/null
+fi
+case $? in
+    1)
+        info "github ssh authentication successful"
+        ;;
+    255)
+        fatal "github ssh authentication failed, ensure ssh is configured for github in order to use this script"
+        ;;
+    *)
+        fatal "github ssh authentication encountered unexpected error"
+esac
+
+# Get list of repo urls from docker compose config
+set +o pipefail
+repos=$(docker-compose config | yq -er '.services | to_entries | .[].value."x-repo-url"' | grep -v 'null' | uniq)
+if [[ ${PIPESTATUS[0]} > 0 ]]; then
+    fatal "failed to list repos, make sure your compose configuration is valid"
+elif [[ ${PIPESTATUS[1]} > 0 ]]; then
+    fatal "unexpected error while parsing docker compose config"
+fi
+
+errors=0
+for repo_url in ${repos[@]}; do
+    # Strip '.git' extension if present
+    repo_url=${repo_url%%}
+
+    # Parse repo URL
+    if [[ "$repo_url" =~ $REPO_URL_REGEX ]]; then
+        org=${BASH_REMATCH[1]}
+        repo=${BASH_REMATCH[2]}
+    else
+        error "failed to parse repo url: '$repo_url'"
+    fi
+
+    # Check if the repo already exits
+    pushd "${DP_REPO_DIR}" > /dev/null
+        if [[ -d "$repo" ]]; then
+            info "repo already cloned, skipping: $repo ($repo_url)"
+        else
+            info "cloning repo...: $repo ($repo_url)"
+
+            # If not then clone it
+            if [[ $VERBOSE = true ]]; then
+                git clone "git@github.com:$org/$repo"
+            else
+                git clone "git@github.com:$org/$repo" 2> /dev/null
+            fi
+            if [[ $? > 0 ]]; then
+                error "failed to clone repo, please make sure the repo exists and you have access to it: $repo ($repo_url)"
+                ((errors++))
+            else
+                info "successfully cloned repo: $repo ($repo_url)"
+            fi
+        fi
+    popd > /dev/null
+done
+
+if [[ $errors > 0 ]]; then
+    error "failed to clone $errors repos"
+else
+    info "all repos have been cloned"
+fi

--- a/v2/scripts/health.sh
+++ b/v2/scripts/health.sh
@@ -12,8 +12,9 @@ fatal() {
 
 # ==| MAIN |================================================================
 
-# Ensure jq is installed
-which jq > /dev/null || fatal "jq not installed"
+# Ensure dependencies are installed
+[[ -n $BASH_VERSINFO && $BASH_VERSINFO -lt 4 ]] && fatal "your 'bash' is too old, please run 'brew install bash'"
+which jq > /dev/null || fatal "jq not installed, please run 'brew install jq'"
 
 # List services (includes stopped and uninitialised services)
 services=( $(docker-compose config --services) )

--- a/v2/stacks/auth/Makefile
+++ b/v2/stacks/auth/Makefile
@@ -45,3 +45,7 @@ __check_defined = \
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh

--- a/v2/stacks/cmd/Makefile
+++ b/v2/stacks/cmd/Makefile
@@ -30,3 +30,7 @@ install:
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh

--- a/v2/stacks/homepage-publishing/Makefile
+++ b/v2/stacks/homepage-publishing/Makefile
@@ -26,3 +26,7 @@ clean:
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh

--- a/v2/stacks/homepage-web/.env
+++ b/v2/stacks/homepage-web/.env
@@ -8,6 +8,7 @@ PATH_PROVISIONING="../../provisioning"
 
 # -- Stack config env vars that override manifest defaults --
 IS_PUBLISHING="false"
+ZEBEDEE_URL=${ZEBEDEE_URL:-http://zebedee-reader:8082}
 
 # -- Docker compose vars -- 
 COMPOSE_FILE=deps.yml:core-ons.yml

--- a/v2/stacks/homepage-web/Makefile
+++ b/v2/stacks/homepage-web/Makefile
@@ -26,3 +26,7 @@ clean:
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh

--- a/v2/stacks/homepage-web/core-ons.yml
+++ b/v2/stacks/homepage-web/core-ons.yml
@@ -24,7 +24,7 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-topic-api.yml
       service: dp-topic-api
-  zebedee:
+  zebedee-reader:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/zebedee-reader.yml
-      service: zebedee
+      service: zebedee-reader

--- a/v2/stacks/search/Makefile
+++ b/v2/stacks/search/Makefile
@@ -30,3 +30,7 @@ install:
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh

--- a/v2/stacks/static-files-with-auth/.env
+++ b/v2/stacks/static-files-with-auth/.env
@@ -37,7 +37,7 @@ DATASET_CONTROLLER_URL=http://http-echo:5678 #http://dp-publishing-dataset-contr
 HOMEPAGE_CONTROLLER_URL=http://dp-frontend-homepage-controller:24400
 DATASET_CONTROLLER_URL=http://http-echo:5678 #http://dp-frontend-dataset-controller:20200
 
-# -- Docker compose vars -- 
+# -- Docker compose vars --
 # https://docs.docker.com/compose/env-file/#compose-file-and-cli-variables
 COMPOSE_FILE=deps.yml:core-ons.yml:static-files.yml
 COMPOSE_PATH_SEPARATOR=:

--- a/v2/stacks/static-files-with-auth/Makefile
+++ b/v2/stacks/static-files-with-auth/Makefile
@@ -26,3 +26,7 @@ clean:
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh

--- a/v2/stacks/static-files/Makefile
+++ b/v2/stacks/static-files/Makefile
@@ -26,3 +26,7 @@ clean:
 .PHONY: health
 health:
 	@../../scripts/health.sh
+
+.PHONY: clone
+clone:
+	@../../scripts/clone.sh


### PR DESCRIPTION
Add a make target that clones all of the git repos for the services defined in the docker compose stack.

This change also standardises the path override for the repo location, replacing the individual `ROOT_${service_name}` with a single `DP_REPO_DIR` env var. While this change does reduce the customisability, it will reduce the issues we see when the repos are not cloned beside each other. The default behaviour will continue to be the same with the app repos being cloned in the same directory as dp-compose.

The documentation needs updating, but this will come in a subsequent change.