### PR TITLE
Feature/fix static files with auth

### DIFF
--- a/v2/manifests/core-ons/dp-files-api.yml
+++ b/v2/manifests/core-ons/dp-files-api.yml
@@ -16,7 +16,7 @@ services:
       BIND_ADDR:                          ":26900"
       GRACEFUL_SHUTDOWN_TIMEOUT:          "30s"
       HEALTHCHECK_CRITICAL_TIMEOUT:       "30s"
-      KAFKA_ADDR:                         "kafka:9092"
+      KAFKA_ADDR:                         "kafka-1:19092,kafka-2:19092,kafka-3:19092"
       KAFKA_PRODUCER_MIN_BROKERS_HEALTHY: "1"
       KAFKA_VERSION:                      "3.1.0"
       KAFKA_MAX_BYTES:                    "2000000"

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -5,6 +5,12 @@ services:
     build:
       context: ${DP_REPO_DIR:-../../../..}/dp-static-file-publisher
       dockerfile: Dockerfile-local
+    command:
+      - reflex
+      - -d
+      - none
+      - -c
+      - ./reflex
     volumes:
       - ${DP_REPO_DIR:-../../../..}/dp-static-file-publisher:/dp-static-file-publisher
     expose:
@@ -20,7 +26,7 @@ services:
       VAULT_ADDR:                         ${VAULT_ADDR:-http://vault:8200}
       VAULT_PATH:                         "secret/shared/psk"
       VAULT_RETRIES:                      "3"
-      KAFKA_ADDR:                         "kafka:9092"
+      KAFKA_ADDR:                         "kafka-1:19092,kafka-2:19092,kafka-3:19092"
       KAFKA_PRODUCER_MIN_BROKERS_HEALTHY: "1"
       KAFKA_VERSION:                      "3.1.0"
       KAFKA_MAX_BYTES:                    "2000000"
@@ -34,7 +40,7 @@ services:
       S3_PUBLIC_BUCKET_NAME:              "testing-public"
       FILES_API_URL:                      ${FILES_API_URL:-http://dp-files-api:26900}
       CONSUMER_GROUP:                     "dp-static-file-publisher"
-      S3_LOCAL_URL:                       ${LOCALSTACK_URL:-http://localstack:4566}
+      S3_LOCAL_URL:                       ${S3_LOCAL_URL:-http://localstack:4566}
       S3_LOCAL_ID:                        "test"
       S3_LOCAL_SECRET:                    "test"
       IMAGE_API_URL:                      ${IMAGE_API_URL:-http://dp-image-api:24700}
@@ -43,4 +49,4 @@ services:
       interval: 30s
       timeout: 10s
       retries: 10
-    entrypoint: make debug
+    #entrypoint: make debug

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -49,4 +49,4 @@ services:
       interval: 30s
       timeout: 10s
       retries: 10
-    #entrypoint: make debug
+

--- a/v2/manifests/core-ons/dp-upload-service.yml
+++ b/v2/manifests/core-ons/dp-upload-service.yml
@@ -29,7 +29,7 @@ services:
       HEALTHCHECK_CRITICAL_TIMEOUT:       "5s"
       VAULT_TOKEN:                        "0000-0000-0000-0000"
       VAULT_ADDR:                         "http://vault:8200"
-      VAULT_PATH':                        "secret/shared/psk"
+      VAULT_PATH:                        "secret/shared/psk"
       FILES_API_URL:                      ${FILES_API_URL:-http://dp-files-api:26900}
       SERVICE_AUTH_TOKEN:                 ${SERVICE_AUTH_TOKEN:?please define a valid SERVICE_AUTH_TOKEN in your local system}
     healthcheck:

--- a/v2/manifests/core-ons/dp-upload-service.yml
+++ b/v2/manifests/core-ons/dp-upload-service.yml
@@ -29,7 +29,7 @@ services:
       HEALTHCHECK_CRITICAL_TIMEOUT:       "5s"
       VAULT_TOKEN:                        "0000-0000-0000-0000"
       VAULT_ADDR:                         "http://vault:8200"
-      VAULT_PATH:                        "secret/shared/psk"
+      VAULT_PATH:                         "secret/shared/psk"
       FILES_API_URL:                      ${FILES_API_URL:-http://dp-files-api:26900}
       SERVICE_AUTH_TOKEN:                 ${SERVICE_AUTH_TOKEN:?please define a valid SERVICE_AUTH_TOKEN in your local system}
     healthcheck:

--- a/v2/manifests/core-ons/project-brian.yml
+++ b/v2/manifests/core-ons/project-brian.yml
@@ -1,0 +1,25 @@
+version: "3.3"
+services:
+  project-brian:
+    x-repo-url: "https://github.com/ONSdigital/project-brian"
+    build:
+      context: ${DP_REPO_DIR:-../../../..}/project-brian
+      dockerfile: Dockerfile
+    expose:
+      - "8083"
+    ports:
+      - 8083:8083
+    restart: unless-stopped
+    user: ${UID-1000}:${GID-1000}
+    volumes:
+      - ${zebedee_root:?please define a valid zebedee_root in your local system}:/zebedee_root
+    environment:
+      TRANSACTION_STORE:           "/zebedee_root/zebedee/transactions"
+      WEBSITE:                     "/zebedee_root/zebedee/master"
+      PUBLISHING_THREAD_POOL_SIZE: 100
+      PORT:                        8083
+      DP_COLOURED_LOGGING:         "true"
+      DP_LOGGING_FORMAT:           "pretty_json"
+      MAX_FILE_UPLOAD_SIZE_MB:     -1
+      MAX_REQUEST_SIZE_MB:         -1
+      FILE_THRESHOLD_SIZE_MB:      0

--- a/v2/manifests/core-ons/zebedee.yml
+++ b/v2/manifests/core-ons/zebedee.yml
@@ -48,6 +48,7 @@ services:
       OTEL_JAVAAGENT_ENABLED:         ${OTEL_JAVAAGENT_ENABLED:-"false"}
       ELASTIC_SEARCH_CLUSTER:         "cluster"
       ELASTIC_SEARCH_SERVER:          "elasticsearch"
+      brian_url:                      "http://project-brian:8083"
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:8082/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/stacks/auth/core-ons.yml
+++ b/v2/stacks/auth/core-ons.yml
@@ -49,8 +49,6 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-files-api.yml
       service: dp-files-api
-    environment:
-      KAFKA_ADDR: 'kafka-1:9092,kafka-2:9093,kafka-3:9094'
     depends_on:
       dp-api-router:
         condition: service_healthy
@@ -89,3 +87,32 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
+  dp-download-service:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-download-service.yml
+      service: dp-download-service
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-upload-service:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-upload-service.yml
+      service: dp-upload-service
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  project-brian:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/project-brian.yml
+      service: project-brian
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-static-file-publisher:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-static-file-publisher.yml
+      service: dp-static-file-publisher
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+

--- a/v2/stacks/auth/core-ons.yml
+++ b/v2/stacks/auth/core-ons.yml
@@ -49,6 +49,8 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-files-api.yml
       service: dp-files-api
+    environment:
+      KAFKA_ADDR: 'kafka-1:9092,kafka-2:9093,kafka-3:9094'
     depends_on:
       dp-api-router:
         condition: service_healthy
@@ -87,32 +89,4 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
-  dp-download-service:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-download-service.yml
-      service: dp-download-service
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  dp-upload-service:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-upload-service.yml
-      service: dp-upload-service
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  project-brian:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/project-brian.yml
-      service: project-brian
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  dp-static-file-publisher:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-static-file-publisher.yml
-      service: dp-static-file-publisher
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-
+ 

--- a/v2/stacks/auth/core-ons.yml
+++ b/v2/stacks/auth/core-ons.yml
@@ -89,4 +89,3 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
- 

--- a/v2/stacks/static-files-with-auth/README.md
+++ b/v2/stacks/static-files-with-auth/README.md
@@ -1,0 +1,38 @@
+# Static Files with Auth Stack
+
+This stack deploys the necessary services and dependencies to work with the static file publishing stack.
+
+The auth stack uses the sandbox cognito instance to store users and their permissions.
+
+## Getting secrets
+
+To run this stack you will need to obtain the relevant secrets for the `local.env` file, which **must not be committed**:
+
+```sh
+# get from AWS > Cognito > User Pools > sandbox-florence-users > user pool ID
+AWS_COGNITO_USER_POOL_ID
+# get from AWS > Cognito > User Pools > sandbox-florence-users > App Integration > App clients > dp-identity-api > client id
+AWS_COGNITO_CLIENT_ID
+# get from AWS > Cognito > User Pools > sandbox-florence-users > App Integration > App clients > dp-identity-api > client secret
+AWS_COGNITO_CLIENT_SECRET
+
+# Below values from the aws login-dashboard or via `aws sts get-session-token`
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+AWS_SESSION_TOKEN
+
+# This should be your locally generated token by Zebedee
+SERVICE_AUTH_TOKEN
+
+# You'll also need your zebedee root for content
+zebedee_root
+```
+
+To get the aws values from the dashboard do the following:
+
+- login to the AWS [console](https://ons.awsapps.com/start#/)
+- click on `Command line or programmatic access`
+- click on `Option 1: Set AWS environment variables (Short-term credentials)`
+- copy the highlighted values
+
+Note that the AWS_SESSION_TOKEN is only valid for 12 hours. Once the token has expired you would need to stop the stack, retrieve and set new credentials before running the stack again.

--- a/v2/stacks/static-files-with-auth/auth.yml
+++ b/v2/stacks/static-files-with-auth/auth.yml
@@ -1,0 +1,14 @@
+version: "3.3"
+services:
+  # new auth
+  dp-permissions-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-permissions-api.yml
+      service: dp-permissions-api
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-identity-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-identity-api.yml
+      service: dp-identity-api

--- a/v2/stacks/static-files-with-auth/core-ons.yml
+++ b/v2/stacks/static-files-with-auth/core-ons.yml
@@ -4,7 +4,120 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/zebedee.yml
       service: zebedee
+    environment:
+      ENABLE_JWT_SESSIONS:            "true"
+      ENABLE_PERMISSIONS_AUTH:        ${ENABLE_PERMISSIONS_AUTH:-1}
+      scheduled_publishing_enabled:   "true"
+    depends_on:
+      dp-identity-api:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
   dp-api-router:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-api-router.yml
       service: dp-api-router
+  florence: # note: this might not build :( manually delete florence/dist florence/src/node_modules florence/assets/data.go
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/florence.yml
+      service: florence
+    environment:
+      ENABLE_NEW_SIGN_IN: "true"
+    depends_on:
+      zebedee:
+        condition: service_healthy
+  dp-frontend-router:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-frontend-router.yml
+      service: dp-frontend-router
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  babbage:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/babbage.yml
+      service: babbage
+    environment:
+      FORMAT_LOGGING: ${FORMAT_LOGGING:-true}
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  sixteens:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/sixteens.yml
+      service: sixteens
+  # dp-files-api:
+  #   extends:
+  #     file: ${PATH_MANIFESTS}/core-ons/dp-files-api.yml
+  #     service: dp-files-api
+  #   depends_on:
+  #     dp-api-router:
+  #       condition: service_healthy
+  the-train:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/the-train.yml
+      service: the-train
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-publishing-dataset-controller:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-publishing-dataset-controller.yml
+      service: dp-publishing-dataset-controller
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-design-system:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-design-system.yml
+      service: dp-design-system
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-image-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-image-api.yml
+      service: dp-image-api
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-image-importer:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-image-importer.yml
+      service: dp-image-importer
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  # dp-download-service:
+  #   extends:
+  #     file: ${PATH_MANIFESTS}/core-ons/dp-download-service.yml
+  #     service: dp-download-service
+  #   environment:
+  #     BUCKET_NAME:       "testing-public"
+  #     IS_PUBLISHING:     "false"
+  #     PUBLIC_BUCKET_URL: "http://localhost:14566/testing-public/"
+  #   depends_on:
+  #     dp-api-router:
+  #       condition: service_healthy
+  # dp-upload-service:
+  #   extends:
+  #     file: ${PATH_MANIFESTS}/core-ons/dp-upload-service.yml
+  #     service: dp-upload-service
+  #   depends_on:
+  #     dp-api-router:
+  #       condition: service_healthy
+  project-brian:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/project-brian.yml
+      service: project-brian
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  # dp-static-file-publisher:
+  #   extends:
+  #     file: ${PATH_MANIFESTS}/core-ons/dp-static-file-publisher.yml
+  #     service: dp-static-file-publisher
+  #   depends_on:
+  #     dp-api-router:
+  #       condition: service_healthy
+

--- a/v2/stacks/static-files-with-auth/core-ons.yml
+++ b/v2/stacks/static-files-with-auth/core-ons.yml
@@ -46,13 +46,6 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/sixteens.yml
       service: sixteens
-  # dp-files-api:
-  #   extends:
-  #     file: ${PATH_MANIFESTS}/core-ons/dp-files-api.yml
-  #     service: dp-files-api
-  #   depends_on:
-  #     dp-api-router:
-  #       condition: service_healthy
   the-train:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/the-train.yml
@@ -88,24 +81,6 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
-  # dp-download-service:
-  #   extends:
-  #     file: ${PATH_MANIFESTS}/core-ons/dp-download-service.yml
-  #     service: dp-download-service
-  #   environment:
-  #     BUCKET_NAME:       "testing-public"
-  #     IS_PUBLISHING:     "false"
-  #     PUBLIC_BUCKET_URL: "http://localhost:14566/testing-public/"
-  #   depends_on:
-  #     dp-api-router:
-  #       condition: service_healthy
-  # dp-upload-service:
-  #   extends:
-  #     file: ${PATH_MANIFESTS}/core-ons/dp-upload-service.yml
-  #     service: dp-upload-service
-  #   depends_on:
-  #     dp-api-router:
-  #       condition: service_healthy
   project-brian:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/project-brian.yml
@@ -113,11 +88,5 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
-  # dp-static-file-publisher:
-  #   extends:
-  #     file: ${PATH_MANIFESTS}/core-ons/dp-static-file-publisher.yml
-  #     service: dp-static-file-publisher
-  #   depends_on:
-  #     dp-api-router:
-  #       condition: service_healthy
+  
 

--- a/v2/stacks/static-files-with-auth/default.env
+++ b/v2/stacks/static-files-with-auth/default.env
@@ -1,9 +1,24 @@
 # -- Global variable overrides --
+IS_PUBLISHING="true"
+AUTHORISATION_ENABLED=false
+
+# -- Paths --
+PATH_MANIFESTS="../../manifests"
+PATH_PROVISIONING="../../provisioning"
+
+# -- Docker compose vars --
+# https://docs.docker.com/compose/environment-variables/envvars/
+COMPOSE_FILE=deps.yml:core-ons.yml:auth.yml:static-files.yml
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_PROJECT_NAME=int-static-files-auth
+COMPOSE_HTTP_TIMEOUT=120
+
+# -- Global variable overrides --
 
 # Backend
 UPLOAD_API_URL=http://host.docker.internal:25100
 DATASET_API_URL=http://http-echo:5678
-IMAGE_API_URL=http://http-echo:5678
+IMAGE_API_URL=http://dp-image-api:24700
 FILTER_API_URL=http://http-echo:5678
 RECIPE_API_URL=http://http-echo:5678
 IMPORT_API_URL=http://http-echo:5678
@@ -12,18 +27,7 @@ RELEASE_CALENDAR_API_URL=http://http-echo:5678
 SEARCH_API_URL=http://http-echo:5678
 
 # Frontend
-BABBAGE_URL=http://http-echo:5678
-DATASET_CONTROLLER_URL=http://http-echo:5678
-HOMEPAGE_CONTROLLER_URL=http://dp-frontend-homepage-controller:24400
-DATASET_CONTROLLER_URL=http://http-echo:5678
-
-# -- Paths --
-PATH_MANIFESTS="../../manifests"
-PATH_PROVISIONING="../../provisioning"
-
-# -- Docker compose vars --
-# https://docs.docker.com/compose/environment-variables/envvars/
-COMPOSE_FILE=deps.yml:core-ons.yml:static-files.yml
-COMPOSE_PATH_SEPARATOR=:
-COMPOSE_PROJECT_NAME=static-auth
-DOCKER_BUILDKIT=0
+#BABBAGE_URL=http://http-echo:5678
+#DATASET_CONTROLLER_URL=http://http-echo:5678
+#HOMEPAGE_CONTROLLER_URL=http://dp-frontend-homepage-controller:24400
+#DATASET_CONTROLLER_URL=http://http-echo:5678

--- a/v2/stacks/static-files-with-auth/default.env
+++ b/v2/stacks/static-files-with-auth/default.env
@@ -15,19 +15,3 @@ COMPOSE_HTTP_TIMEOUT=120
 
 # -- Global variable overrides --
 
-# Backend
-UPLOAD_API_URL=http://host.docker.internal:25100
-DATASET_API_URL=http://http-echo:5678
-IMAGE_API_URL=http://dp-image-api:24700
-FILTER_API_URL=http://http-echo:5678
-RECIPE_API_URL=http://http-echo:5678
-IMPORT_API_URL=http://http-echo:5678
-TOPIC_API_URL=http://http-echo:5678
-RELEASE_CALENDAR_API_URL=http://http-echo:5678
-SEARCH_API_URL=http://http-echo:5678
-
-# Frontend
-#BABBAGE_URL=http://http-echo:5678
-#DATASET_CONTROLLER_URL=http://http-echo:5678
-#HOMEPAGE_CONTROLLER_URL=http://dp-frontend-homepage-controller:24400
-#DATASET_CONTROLLER_URL=http://http-echo:5678

--- a/v2/stacks/static-files-with-auth/deps.yml
+++ b/v2/stacks/static-files-with-auth/deps.yml
@@ -1,28 +1,48 @@
 version: "3.3"
 services:
-  postgis:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/postgis.yml
-      service: postgis
-  vault:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/vault.yml
-      service: vault
-  kafka:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/kafka.yml
-      service: kafka
   mongodb:
     extends:
       file: ${PATH_MANIFESTS}/deps/mongo.yml
       service: mongodb
     volumes:
       - ${PATH_PROVISIONING}/mongo/init.js:/docker-entrypoint-initdb.d/init.js:ro
+  zookeeper-1:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka-confluentinc.yml
+      service: zookeeper-1
+  kafka-1:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka-confluentinc.yml
+      service: kafka-1
+    depends_on:
+      - zookeeper-1
+  kafka-2:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka-confluentinc.yml
+      service: kafka-2
+    depends_on:
+      - zookeeper-1
+  kafka-3:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka-confluentinc.yml
+      service: kafka-3
+    depends_on:
+      - zookeeper-1
+  vault:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/vault.yml
+      service: vault
+  kowl:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka-tools.yml
+      service: kowl
+    depends_on:
+      - zookeeper-1
   localstack:
     extends:
       file: ${PATH_MANIFESTS}/deps/localstack.yml
       service: localstack
-  http-echo:
+  elasticsearch:
     extends:
-      file: ${PATH_MANIFESTS}/deps/http-echo.yml
-      service: http-echo
+      file: ${PATH_MANIFESTS}/deps/elasticsearch.yml
+      service: elasticsearch

--- a/v2/stacks/static-files-with-auth/local.env
+++ b/v2/stacks/static-files-with-auth/local.env
@@ -1,0 +1,28 @@
+# ==| LOCAL ENV VARS OVERRIDES |===================================
+#
+# Use the local.env file to:
+#
+# 1. Add required env vars specified in the Configuration section of
+#    the README. These can include secret values as this file is git
+#    ignored.
+#
+# 2. Override the default environment variables specified in the
+#    stack's `default.env` file. This can be useful for toggling feature
+#    flags, routing requests to/from an app running in your IDE or
+#    any other customisation you want to make for your local use.
+#
+# For example:
+# DP_PING="pong"
+#
+# For more information on the syntax see the docs:
+# https://docs.docker.com/compose/environment-variables/env-file/#syntax
+# get from cognito: sandbox-florence-users
+AWS_COGNITO_USER_POOL_ID=""
+# get from within pool - App Integration: App client: dp-identity-api
+AWS_COGNITO_CLIENT_ID=""
+# get from within pool - App Integration: App client: dp-identity-api
+AWS_COGNITO_CLIENT_SECRET=""
+
+AWS_ACCESS_KEY_ID=""
+AWS_SECRET_ACCESS_KEY=""
+AWS_SESSION_TOKEN=""

--- a/v2/stacks/static-files-with-auth/static-files.yml
+++ b/v2/stacks/static-files-with-auth/static-files.yml
@@ -12,12 +12,19 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-download-service.yml
       service: dp-download-service
-  # new auth
-  dp-permissions-api:
+    environment:
+      BUCKET_NAME:       "testing-public"
+      IS_PUBLISHING:     "false"
+      PUBLIC_BUCKET_URL: "http://localhost:14566/testing-public/"
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+  dp-static-file-publisher:
     extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-permissions-api.yml
-      service: dp-permissions-api
-  dp-identity-api:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-identity-api.yml
-      service: dp-identity-api
+      file: ${PATH_MANIFESTS}/core-ons/dp-static-file-publisher.yml
+      service: dp-static-file-publisher
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+
+


### PR DESCRIPTION
Updating the static files with auth stack so that it is possible to publish a collection and use the static files functionality.

To test, please clone this branch and cd in to the /v2/static-files-with-auth directory. Follow the instructions in the readme to set cognito variables in the local.env file and run the command 

```go
make up
``` 

All containers should run.  