### PR TITLE
Update the Readme for the Auth Stack

### DIFF
--- a/v2/stacks/auth/README.md
+++ b/v2/stacks/auth/README.md
@@ -9,11 +9,14 @@ The auth stack uses the sandbox cognito instance to store users and their permis
 To run this stack you will need to obtain the relevant secrets for the `local.env` file, which **must not be committed**:
 
 ```sh
-# get from AWS > Cognito > User Pools > sandbox-florence-users > user pool ID
+# get from:
+# AWS > Cognito > User Pools > sandbox-florence-users > user pool ID
 AWS_COGNITO_USER_POOL_ID
-# get from AWS > Cognito > User Pools > sandbox-florence-users > App Integration > App clients > dp-identity-api > client id
+# get from:
+# AWS > Cognito > User Pools > sandbox-florence-users > App Integration > App clients > dp-identity-api > client id
 AWS_COGNITO_CLIENT_ID
-# get from AWS > Cognito > User Pools > sandbox-florence-users > App Integration > App clients > dp-identity-api > client secret
+# get from:
+# AWS > Cognito > User Pools > sandbox-florence-users > App Integration > App clients > dp-identity-api > client secret
 AWS_COGNITO_CLIENT_SECRET
 
 # Below values from the aws login-dashboard or via `aws sts get-session-token`
@@ -25,14 +28,35 @@ AWS_SESSION_TOKEN
 SERVICE_AUTH_TOKEN
 
 # You'll also need your zebedee root for content
+# E.g. zebedee_root=/Users/your-name/zebedee-content
 zebedee_root
+
+# You may also need these AWS settings. The profile should point to sandbox.
+AWS_PROFILE
+AWS_REGION
+
+# You may also need the following other environment variables. Get the values from the relevant secrets in sandbox:
+
+# WEBSITE and PUBLISHING_THREAD_POOL_SIZE and TRANSACTION_STORE from the-train
+WEBSITE
+PUBLISHING_THREAD_POOL_SIZE
+TRANSACTION_STORE
+
+# ENABLE_PRIVATE_ENDPOINTS from dp-api-router
+ENABLE_PRIVATE_ENDPOINTS
+
+# ENABLE_PERMISSIONS_AUTH from zebedee
+ENABLE_PERMISSIONS_AUTH
+
+# IS_PUBLISHING from the permissions api and/or the files api and/or the image api
+IS_PUBLISHING
 ```
 
 To get the aws values from the dashboard do the following:
 
-- login to the AWS [console](https://ons.awsapps.com/start#/)
-- click on `Command line or programmatic access`
-- click on `Option 1: Set AWS environment variables (Short-term credentials)`
-- copy the highlighted values
+- Login to the AWS [console](https://ons.awsapps.com/start#/).
+- Expand ons-dp-sandbox and click on `Access keys`.
+- Expand `Option 1: Set AWS environment variables` and click the copy button.
+- Copy the values into your local.env file. Delete the word 'export' from each line. But keep the quotes around the values. NB. These are the only values in your local.env that may need to have quotes around them.
 
 Note that the AWS_SESSION_TOKEN is only valid for 12 hours. Once the token has expired you would need to stop the stack, retrieve and set new credentials before running the stack again.


### PR DESCRIPTION
The readme has been updated to reflect changes to the AWS login UI in the relevant steps and to give more details of what environment variables might need to be set in the local.env so that the Auth stack will show previews in Florence.