### PR TITLE
Feature/docker v26

### DIFF
--- a/v2/manifests/core-ons/babbage.yml
+++ b/v2/manifests/core-ons/babbage.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   babbage:
     x-repo-url: "https://github.com/ONSdigital/babbage"

--- a/v2/manifests/core-ons/dp-api-router.yml
+++ b/v2/manifests/core-ons/dp-api-router.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-api-router:
     x-repo-url: "https://github.com/ONSdigital/dp-api-router"

--- a/v2/manifests/core-ons/dp-code-list-api.yml
+++ b/v2/manifests/core-ons/dp-code-list-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-code-list-api:
     x-repo-url: "https://github.com/ONSdigital/dp-code-list-api"

--- a/v2/manifests/core-ons/dp-dataset-api.yml
+++ b/v2/manifests/core-ons/dp-dataset-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-dataset-api:
     x-repo-url: "https://github.com/ONSdigital/dp-dataset-api"

--- a/v2/manifests/core-ons/dp-design-system.yml
+++ b/v2/manifests/core-ons/dp-design-system.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-design-system:
     x-repo-url: "https://github.com/ONSdigital/dp-design-system"

--- a/v2/manifests/core-ons/dp-dimension-extractor.yml
+++ b/v2/manifests/core-ons/dp-dimension-extractor.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-dimension-extractor:
     x-repo-url: "https://github.com/ONSdigital/dp-dimension-extractor"

--- a/v2/manifests/core-ons/dp-dimension-importer.yml
+++ b/v2/manifests/core-ons/dp-dimension-importer.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-dimension-importer:
     x-repo-url: "https://github.com/ONSdigital/dp-dimension-importer"

--- a/v2/manifests/core-ons/dp-dimension-search-builder.yml
+++ b/v2/manifests/core-ons/dp-dimension-search-builder.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-dimension-search-builder:
     x-repo-url: "https://github.com/ONSdigital/dp-dimension-search-builder"

--- a/v2/manifests/core-ons/dp-download-service.yml
+++ b/v2/manifests/core-ons/dp-download-service.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-download-service:
     x-repo-url: "https://github.com/ONSdigital/dp-download-service"

--- a/v2/manifests/core-ons/dp-files-api.yml
+++ b/v2/manifests/core-ons/dp-files-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-files-api:
     x-repo-url: "https://github.com/ONSdigital/dp-files-api"

--- a/v2/manifests/core-ons/dp-frontend-cookie-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-cookie-controller.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-frontend-cookie-controller:
     x-repo-url: "https://github.com/ONSdigital/dp-frontend-cookie-controller"

--- a/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-frontend-dataset-controller:
     x-repo-url: "https://github.com/ONSdigital/dp-frontend-dataset-controller"

--- a/v2/manifests/core-ons/dp-frontend-homepage-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-homepage-controller.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-frontend-homepage-controller:
     x-repo-url: "https://github.com/ONSdigital/dp-frontend-homepage-controller"

--- a/v2/manifests/core-ons/dp-frontend-release-calendar.yml
+++ b/v2/manifests/core-ons/dp-frontend-release-calendar.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-frontend-release-calendar:
     x-repo-url: "https://github.com/ONSdigital/dp-frontend-release-calendar"

--- a/v2/manifests/core-ons/dp-frontend-router.yml
+++ b/v2/manifests/core-ons/dp-frontend-router.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-frontend-router:
     x-repo-url: "https://github.com/ONSdigital/dp-frontend-router"

--- a/v2/manifests/core-ons/dp-frontend-search-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-search-controller.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-frontend-search-controller:
     x-repo-url: "https://github.com/ONSdigital/dp-frontend-search-controller"

--- a/v2/manifests/core-ons/dp-hierarchy-api.yml
+++ b/v2/manifests/core-ons/dp-hierarchy-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-hierarchy-api:
     x-repo-url: "https://github.com/ONSdigital/dp-hierarchy-api"

--- a/v2/manifests/core-ons/dp-hierarchy-builder.yml
+++ b/v2/manifests/core-ons/dp-hierarchy-builder.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-hierarchy-builder:
     x-repo-url: "https://github.com/ONSdigital/dp-hierarchy-builder"

--- a/v2/manifests/core-ons/dp-identity-api.yml
+++ b/v2/manifests/core-ons/dp-identity-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-identity-api:
     x-repo-url: "https://github.com/ONSdigital/dp-identity-api"

--- a/v2/manifests/core-ons/dp-image-api.yml
+++ b/v2/manifests/core-ons/dp-image-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-image-api:
     x-repo-url: "https://github.com/ONSdigital/dp-image-api"

--- a/v2/manifests/core-ons/dp-image-importer.yml
+++ b/v2/manifests/core-ons/dp-image-importer.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-image-importer:
     x-repo-url: "https://github.com/ONSdigital/dp-image-importer"

--- a/v2/manifests/core-ons/dp-import-api.yml
+++ b/v2/manifests/core-ons/dp-import-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-import-api:
     x-repo-url: "https://github.com/ONSdigital/dp-import-api"

--- a/v2/manifests/core-ons/dp-import-tracker.yml
+++ b/v2/manifests/core-ons/dp-import-tracker.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-import-tracker:
     x-repo-url: "https://github.com/ONSdigital/dp-import-tracker"

--- a/v2/manifests/core-ons/dp-observation-extractor.yml
+++ b/v2/manifests/core-ons/dp-observation-extractor.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-observation-extractor:
     x-repo-url: "https://github.com/ONSdigital/dp-observation-extractor"

--- a/v2/manifests/core-ons/dp-observation-importer.yml
+++ b/v2/manifests/core-ons/dp-observation-importer.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-observation-importer:
     x-repo-url: "https://github.com/ONSdigital/dp-observation-importer"

--- a/v2/manifests/core-ons/dp-permissions-api.yml
+++ b/v2/manifests/core-ons/dp-permissions-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-permissions-api:
     x-repo-url: "https://github.com/ONSdigital/dp-permissions-api"

--- a/v2/manifests/core-ons/dp-population-types-api.yml
+++ b/v2/manifests/core-ons/dp-population-types-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-population-types-api:
     x-repo-url: "https://github.com/ONSdigital/dp-population-types-api"

--- a/v2/manifests/core-ons/dp-publishing-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-publishing-dataset-controller.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-publishing-dataset-controller:
     x-repo-url: "https://github.com/ONSdigital/dp-publishing-dataset-controller"

--- a/v2/manifests/core-ons/dp-recipe-api.yml
+++ b/v2/manifests/core-ons/dp-recipe-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-recipe-api:
     x-repo-url: "https://github.com/ONSdigital/dp-recipe-api"

--- a/v2/manifests/core-ons/dp-release-calendar-api.yml
+++ b/v2/manifests/core-ons/dp-release-calendar-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-release-calendar-api:
     x-repo-url: "https://github.com/ONSdigital/dp-release-calendar-api"

--- a/v2/manifests/core-ons/dp-search-api.yml
+++ b/v2/manifests/core-ons/dp-search-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-search-api:
     x-repo-url: "https://github.com/ONSdigital/dp-search-api"

--- a/v2/manifests/core-ons/dp-search-data-extractor.yml
+++ b/v2/manifests/core-ons/dp-search-data-extractor.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-search-data-extractor:
     x-repo-url: "https://github.com/ONSdigital/dp-search-data-extractor"

--- a/v2/manifests/core-ons/dp-search-data-finder.yml
+++ b/v2/manifests/core-ons/dp-search-data-finder.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-search-data-finder:
     x-repo-url: "https://github.com/ONSdigital/dp-search-data-finder"

--- a/v2/manifests/core-ons/dp-search-data-importer.yml
+++ b/v2/manifests/core-ons/dp-search-data-importer.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-search-data-importer:
     x-repo-url: "https://github.com/ONSdigital/dp-search-data-importer"

--- a/v2/manifests/core-ons/dp-search-reindex-api.yml
+++ b/v2/manifests/core-ons/dp-search-reindex-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-search-reindex-api:
     x-repo-url: "https://github.com/ONSdigital/dp-search-reindex-api"

--- a/v2/manifests/core-ons/dp-search-reindex-tracker.yml
+++ b/v2/manifests/core-ons/dp-search-reindex-tracker.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-search-reindex-tracker:
     x-repo-url: "https://github.com/ONSdigital/dp-search-reindex-tracker"

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-static-file-publisher:
     x-repo-url: "https://github.com/ONSdigital/dp-static-file-publisher"

--- a/v2/manifests/core-ons/dp-topic-api.yml
+++ b/v2/manifests/core-ons/dp-topic-api.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-topic-api:
     x-repo-url: "https://github.com/ONSdigital/dp-topic-api"

--- a/v2/manifests/core-ons/dp-upload-service.yml
+++ b/v2/manifests/core-ons/dp-upload-service.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-upload-service:
     x-repo-url: "https://github.com/ONSdigital/dp-upload-service"

--- a/v2/manifests/core-ons/florence.yml
+++ b/v2/manifests/core-ons/florence.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   florence:
     x-repo-url: "https://github.com/ONSdigital/florence"

--- a/v2/manifests/core-ons/project-brian.yml
+++ b/v2/manifests/core-ons/project-brian.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   project-brian:
     x-repo-url: "https://github.com/ONSdigital/project-brian"

--- a/v2/manifests/core-ons/sixteens.yml
+++ b/v2/manifests/core-ons/sixteens.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   sixteens:
     x-repo-url: "https://github.com/ONSdigital/sixteens"

--- a/v2/manifests/core-ons/the-train.yml
+++ b/v2/manifests/core-ons/the-train.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   the-train:
     x-repo-url: "https://github.com/ONSdigital/the-train"

--- a/v2/manifests/core-ons/zebedee-reader.yml
+++ b/v2/manifests/core-ons/zebedee-reader.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   zebedee-reader:
     x-repo-url: "https://github.com/ONSdigital/zebedee"

--- a/v2/manifests/core-ons/zebedee.yml
+++ b/v2/manifests/core-ons/zebedee.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   zebedee:
     x-repo-url: "https://github.com/ONSdigital/zebedee"

--- a/v2/manifests/deps/elasticsearch.yml
+++ b/v2/manifests/deps/elasticsearch.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
 
   elasticsearch:

--- a/v2/manifests/deps/http-echo.yml
+++ b/v2/manifests/deps/http-echo.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   http-echo:
     platform: linux/amd64

--- a/v2/manifests/deps/kafka-confluentinc.yml
+++ b/v2/manifests/deps/kafka-confluentinc.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   zookeeper-1:
     image: confluentinc/cp-zookeeper:6.0.0

--- a/v2/manifests/deps/kafka-tools.yml
+++ b/v2/manifests/deps/kafka-tools.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   kowl:
     image: quay.io/cloudhut/kowl:master

--- a/v2/manifests/deps/kafka.yml
+++ b/v2/manifests/deps/kafka.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   kafka:
     image: bitnami/kafka:3.1.0

--- a/v2/manifests/deps/localstack.yml
+++ b/v2/manifests/deps/localstack.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   localstack:
     image: localstack/localstack

--- a/v2/manifests/deps/mongo.yml
+++ b/v2/manifests/deps/mongo.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   mongodb:
     image: mongo:3.6

--- a/v2/manifests/deps/postgis.yml
+++ b/v2/manifests/deps/postgis.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:  
   postgis:
     image: postgis/postgis

--- a/v2/manifests/deps/prometheus.yml
+++ b/v2/manifests/deps/prometheus.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services: 
   prometheus:
     image: prom/prometheus

--- a/v2/manifests/deps/vault.yml
+++ b/v2/manifests/deps/vault.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   vault:
     image: hashicorp/vault:latest

--- a/v2/manifests/deps/zookeeper.yml
+++ b/v2/manifests/deps/zookeeper.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   zookeeper:
     image: 'bitnami/zookeeper:latest'

--- a/v2/stacks/auth/auth.yml
+++ b/v2/stacks/auth/auth.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   # new auth
   dp-permissions-api:

--- a/v2/stacks/auth/core-ons.yml
+++ b/v2/stacks/auth/core-ons.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   zebedee:
     extends:

--- a/v2/stacks/auth/deps.yml
+++ b/v2/stacks/auth/deps.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   mongodb:
     extends:

--- a/v2/stacks/cmd/core-ons.yml
+++ b/v2/stacks/cmd/core-ons.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   sixteens:
     extends:

--- a/v2/stacks/cmd/deps.yml
+++ b/v2/stacks/cmd/deps.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   mongodb:
     extends:

--- a/v2/stacks/cmd/import.yml
+++ b/v2/stacks/cmd/import.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-code-list-api:
     extends:

--- a/v2/stacks/common.mk
+++ b/v2/stacks/common.mk
@@ -150,8 +150,8 @@ check-versions:
 	@source $(SCRIPTS_DIR)/utils.sh;	\
 		is_ver java		"$$(java -version		2>&1 | sed -En 's/.* version "(.*)"$$/\1/p')"		"1\.8\.*";		\
 		is_ver maven		"$$(mvn --version		2>&1 | sed -En 's/.* Maven ([0-9]+\..*) .*/\1/p')"	"3\.*";			\
-		is_ver docker		"$$(docker --version		2>&1 | sed -En 's/.* version ([^ ]+), .*/\1/p')"		"25\.*";		\
-		is_ver docker-compose	"$$(docker-compose --version	2>&1 | sed -En 's/.* version v?([0-9.]+.*)/\1/p')"	"2\.2?\.*";		\
+		is_ver docker		"$$(docker --version		2>&1 | sed -En 's/.* version ([^ ]+), .*/\1/p')"	"2[5-9]\.*";		\
+		is_ver docker-compose	"$$(docker-compose --version	2>&1 | sed -En 's/.* version v?([0-9.]+.*)/\1/p')"	"2\.2[5-9]\.*";		\
 		: is_ver nvm		"$$(nvm --version		2>&1 )"							"0\.[3-9][0-9]\..*";	\
 		: is_ver npm		"$$(npm --version		2>&1 )"							"0\.[3-9][0-9]\..*"
 

--- a/v2/stacks/homepage-publishing/core-ons.yml
+++ b/v2/stacks/homepage-publishing/core-ons.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-design-system:
     extends:

--- a/v2/stacks/homepage-publishing/deps.yml
+++ b/v2/stacks/homepage-publishing/deps.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   mongodb:
     extends:

--- a/v2/stacks/homepage-web/core-ons.yml
+++ b/v2/stacks/homepage-web/core-ons.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-design-system:
     extends:

--- a/v2/stacks/homepage-web/deps.yml
+++ b/v2/stacks/homepage-web/deps.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   mongodb:
     extends:

--- a/v2/stacks/search/backend-with-mappings.yml
+++ b/v2/stacks/search/backend-with-mappings.yml
@@ -5,7 +5,6 @@
 # It assumes that these dependencies will be available in localhost.
 # `extra_hosts` blocks are used to do this mapping.
 
-version: "3.3"
 services:
   dp-search-api:
     extends:

--- a/v2/stacks/search/backend.yml
+++ b/v2/stacks/search/backend.yml
@@ -3,7 +3,6 @@
 # Contains all the search stack backend services.
 # This is a self-contained stack that doesn't rely on any external mapping or running service
 
-version: "3.3"
 services:
   dp-search-api:
     extends:

--- a/v2/stacks/search/deps.yml
+++ b/v2/stacks/search/deps.yml
@@ -2,7 +2,6 @@
 
 # Contains all the search stack non-ons dependencies.
 
-version: "3.3"
 services:
   sitewideelasticsearch:
     extends:

--- a/v2/stacks/search/frontend.yml
+++ b/v2/stacks/search/frontend.yml
@@ -2,7 +2,6 @@
 
 # Contains all the search stack frontend services.
 
-version: "3.3"
 services:
   babbage:
     extends:

--- a/v2/stacks/search/publishing.yml
+++ b/v2/stacks/search/publishing.yml
@@ -3,7 +3,6 @@
 # Contains all the search stack publishing services.
 # This is a self-contained stack that doesn't rely on any external mapping or running service
 
-version: "3.3"
 services:
   florence:
     extends:

--- a/v2/stacks/search/reindex.yml
+++ b/v2/stacks/search/reindex.yml
@@ -2,7 +2,6 @@
 
 # Contains all the search stack reindex pipeline applications.
 
-version: "3.3"
 services:
   dp-search-reindex-api:
     extends:

--- a/v2/stacks/static-files-with-auth/auth.yml
+++ b/v2/stacks/static-files-with-auth/auth.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   # new auth
   dp-permissions-api:

--- a/v2/stacks/static-files-with-auth/core-ons.yml
+++ b/v2/stacks/static-files-with-auth/core-ons.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   zebedee:
     extends:

--- a/v2/stacks/static-files-with-auth/deps.yml
+++ b/v2/stacks/static-files-with-auth/deps.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   mongodb:
     extends:

--- a/v2/stacks/static-files-with-auth/static-files.yml
+++ b/v2/stacks/static-files-with-auth/static-files.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-files-api:
     extends:

--- a/v2/stacks/static-files/core-ons.yml
+++ b/v2/stacks/static-files/core-ons.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-api-router:
     extends:

--- a/v2/stacks/static-files/deps.yml
+++ b/v2/stacks/static-files/deps.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   postgis:
     extends:

--- a/v2/stacks/static-files/static-files.yml
+++ b/v2/stacks/static-files/static-files.yml
@@ -1,4 +1,3 @@
-version: "3.3"
 services:
   dp-files-api:
     extends:


### PR DESCRIPTION
- the `version` line in docker config files (YAML) has long been deprecated,
- but with the latest version of docker, it [now complains](https://github.com/docker/compose/issues/11628) that it is `obsolete`

so this branch
- updates `make check` to allow the new docker
- removes all the offending `version` lines