### PR TITLE
Feature/fix data api stack with dependant services

### DIFF
--- a/v2/stacks/data-api/core-ons.yml
+++ b/v2/stacks/data-api/core-ons.yml
@@ -61,5 +61,10 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
-
-        
+  dp-filter-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-filter-api.yml
+      service: dp-filter-api
+    depends_on:
+      dp-api-router:
+        condition: service_healthy

--- a/v2/stacks/data-api/core-ons.yml
+++ b/v2/stacks/data-api/core-ons.yml
@@ -54,3 +54,12 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
+  dp-image-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-image-api.yml
+      service: dp-image-api
+    depends_on:
+      dp-api-router:
+        condition: service_healthy
+
+        

--- a/v2/stacks/data-api/core-ons.yml
+++ b/v2/stacks/data-api/core-ons.yml
@@ -68,3 +68,7 @@ services:
     depends_on:
       dp-api-router:
         condition: service_healthy
+  dp-frontend-dataset-controller:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-frontend-dataset-controller.yml
+      service: dp-frontend-dataset-controller


### PR DESCRIPTION
- Added following services into data-api stack

  - dp-image-api
  - dp-filter-api
  - dp-frontend-dataset-controller

- Check if the builds are passed

- Test locally if the data-api stack services starts healthy (dp-download-service, dp-static-file-publisher)