### PR TITLE
Created dis-data-admin-ui.yml file and added it to core-ons.yml for dataset catalogue stack

### DIFF
--- a/v2/manifests/core-ons/dis-data-admin-ui.yml
+++ b/v2/manifests/core-ons/dis-data-admin-ui.yml
@@ -1,0 +1,20 @@
+services:
+  dis-data-admin-ui:
+    x-repo-url: "https://github.com/ONSdigital/dis-data-admin-ui"
+    build:
+      context: ${DP_REPO_DIR:-../../../..}/dis-data-admin-ui
+      dockerfile: Dockerfile.local
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dis-data-admin-ui:/dis-data-admin-ui
+    expose:
+      - "29400"
+    ports:
+      - 29400:29400
+    restart: unless-stopped
+    environment:
+      BIND_ADDR:                      ":29400"
+    healthcheck:
+      test: ["CMD", "curl", "-sSf", "http://localhost:29400/data-admin/api/health"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/stacks/dataset-catalogue/core-ons.yml
+++ b/v2/stacks/dataset-catalogue/core-ons.yml
@@ -62,3 +62,7 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-frontend-dataset-controller.yml
       service: dp-frontend-dataset-controller
+  dis-data-admin-ui:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dis-data-admin-ui.yml
+      service: dis-data-admin-ui


### PR DESCRIPTION
What has changed:

- As the title states

To test:

1. Pull down feature/add-data-admin-ui-to-dataset-catalogue-stack.
2. Check out develop for dis-data-admin-ui.
3. Run make up from dp-compose/v2/stacks/dataset-catalogue.
4. Open browser and go to http://localhost:29400/data-admin.
5. Hopefully see the data-admin home screen.