### PR TITLE
Add a v1 compatible v2 stack and migration guide for transition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,33 @@
+.PHONY: deprecated
+deprecated:
+	@echo "\033[33m""⚠️ DEPRECATED ⚠️: This stack is deprecated and will be removed soon. Please see README.md#upgrading-to-v2 to upgrade now.\033[0m"
+
 .PHONY: start
-start:
+start: deprecated
 	@echo "starting dp-compose containers"
 	docker-compose up
 
 .PHONY: start-detached
-start-detached:
+start-detached: deprecated
 	@echo "starting dp-compose containers in background"
 	docker-compose up -d
 
 .PHONY: stop
-stop:
+stop: deprecated
 	@echo "stopping dp-compose containers"
 	docker-compose stop
 
 .PHONY: down
-down:
+down: deprecated
 	@echo "stopping and removing dp-compose containers and networks"
 	docker-compose down
 
 .PHONY: clean
-clean:
+clean: deprecated
 	@echo "stopping and removing dp-compose containers, associated volumes and networks"
 	docker-compose down -v
 
 .PHONY: restart
-restart:
+restart: deprecated
 	@echo "restarting dp-compose containers"
 	docker-compose restart

--- a/README.md
+++ b/README.md
@@ -2,44 +2,40 @@
 
 A project to assist in composing multiple DP services
 
+## Getting started
+
+### V2
+
+There is a version 2 folder (`v2`), which contains different docker compose definitions for each stack.
+
+Please, have a look at the [version 2 README](./v2/README.md) for more information, especially if you are new to dp-compose.
+
+#### Upgrading to V2
+
+If you were using the original stack provided in the root of this repo, this stack has been retired so you will need to upgrade to v2.
+
+In order to smooth the transition to v2, a [`v1-compat`](v2/stacks/v1-compat/) stack has been created that provides the same services as the original v1 stack. Differences exist in the make targets so please see the [`v1-compat` readme](v2/stacks/v1-compat/README.md#migrating-from-the-v1-stack) for more details.
+
+### Non-v2 stacks
+
+There are some stacks in this directory (not the `v2/` directory) which are similar to V2 stacks. These stacks formed the basis for the approach taken with V2, but have yet to be migrated to be inline with V2 themselves:
+
+* [cantabular-import](./cantabular-import/)
+* [cantabular-metadata-pub](./cantabular-metadata-pub/)
+
+These stacks will be migrated under v2 in time and no further stacks should be added outside of v2.
+
+These stacks also assume you already have Colima running. See the section on [Colima](#colima) for more information.
+
+## Colima
+
 Running dp-compose assumes Docker is running natively and not in a VM. On a Mac this requires Colima:
 
 [Setting up Colima locally](setting-up-colima-locally.md)
 
-## V2
+## Kafka
 
-There is a version 2 folder (`v2`), which contains different docker compose definitions for each stack.
-
-Please, have a look at the [version 2 README](./v2/README.md) for more information,
-especially if you are new to dp-compose.
-
-## Non-v2 stacks
-
-There are some stacks in this directory (not the `v2` directory) which follow the below documentation, but we recommend starting with the (above) V2 stacks before using these.
-
-More information about the kafka cluster [here](./kafka-cluster.md).
-
-### Run
-
-You may run containers for all required backing services by doing one of the following:
-
-- Run `docker-compose up`
-- Using the `./run.sh` script does the same thing.
-- Run `make start` to start the kafka cluster containers
-
-You can run `make stop` to stop the containers, or `make clean` to stop and remove them as well.
-
-**If you're running for the first time** you will need to seed the Mongo database and create the collections for the first time. Run the [init-db.sh](https://github.com/ONSdigital/dp-compose/blob/main/cantabular-import/helpers/init-db.sh) script to create recipe and dataset related collections.
-
-## CMD
-
-The ONS website and CMD both require Elasticsearch but (annoyingly) require different versions. The `docker-compose.yml` will start 2 instances.
-
-**Note:** The default ports for Elasticsearch is usually `9200` & `9300` however in order to avoid a port conflict
- when running 2 different versions on the same box at the same time the CMD instance is set to use ports `10200` & `10300`.
-
-:warning: **Gotcha Warning** :warning:
-You'll need to overwrite your ES config for the `dp-dimension-search-builder` and `dp-dimension-search-api` to use ports `10200` & `10300` to ensure they are using the correct instance.
+More information about working with the kafka cluster provided by stacks in this repo can be found [here](./kafka-cluster.md).
 
 ## Versioning
 

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+echo -e "\033[33m""⚠️ DEPRECATED ⚠️: This stack is deprecated and will be removed soon. Please see README.md#upgrading-to-v2 to upgrade now.\033[0m"
+
 docker-compose up

--- a/v2/manifests/core-ons/mathjax-api.yml
+++ b/v2/manifests/core-ons/mathjax-api.yml
@@ -1,0 +1,16 @@
+services:
+  mathjax:
+    x-repo-url: "https://github.com/ONSdigital/mathjax-api"
+    build:
+      context: ${DP_REPO_DIR:-../../../..}/mathjax-api
+      dockerfile: Dockerfile
+    expose:
+      - "8888"
+    ports:
+      - "8888:8080"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-sSf", "http://localhost:8080/"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/manifests/deps/highcharts.yml
+++ b/v2/manifests/deps/highcharts.yml
@@ -1,5 +1,12 @@
 services:
   highcharts:
+    x-repo-url: "https://github.com/ONSdigital/highcharts-export-docker"
+    # Using the prebuilt image for now as work is needed to pin the versions in the docker build
     image: onsdigital/highcharts-export-node
     ports:
       - "9999:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-sSf", "http://localhost:8080/health"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/stacks/v1-compat/Makefile
+++ b/v2/stacks/v1-compat/Makefile
@@ -1,0 +1,8 @@
+# Include common make targets
+include ../common.mk
+
+.PHONY: init
+init: base-init
+	# Add stack specific initialisation logic here
+
+# Add any stack specific helper targets here

--- a/v2/stacks/v1-compat/README.md
+++ b/v2/stacks/v1-compat/README.md
@@ -1,0 +1,35 @@
+# v1 Compatability Stack
+
+:warning: This stack is only provided for backwards compatability with the original docker compose stack. It is strongly recommended that you use the product specific stacks. This stack should be treated as deprecated and not be extended.
+
+This stack only provides the third party backing services and the MathJax API. It provides backwards compatability as a replacement for the original `docker-compose.yml` from the root of this repo.
+
+## Getting started
+
+To run the stack:
+
+1. Clone the repos needed for the stack:
+
+   ```shell
+   make clone
+   ```
+
+2. Build and start the stack:
+
+   ```shell
+   make up
+   ```
+
+For more information on working with the stack and other make targets, see the [general stack guidance](../README.md#general-guidance-for-each-stack).
+
+## Is it running successfully?
+
+You can test your stack is running correctly by running the health checks:
+
+```shell
+make health
+```
+
+## Is it complete?
+
+Yes, this stack provides all services provided by the original docker compose stack so can be used as a replacement.

--- a/v2/stacks/v1-compat/README.md
+++ b/v2/stacks/v1-compat/README.md
@@ -33,3 +33,37 @@ make health
 ## Is it complete?
 
 Yes, this stack provides all services provided by the original docker compose stack so can be used as a replacement.
+
+## Migrating from v1
+
+When migrating from the v1 stack (i.e. the original docker compose stack that used to exist in the root of this repo), the commands you use to interact with this stack will be slightly different. The most notable difference is that v2 defaults to always running in detatched mode rather than following the logs for performance reasons. If you wish to follow the logs after starting an app, the additional target `LOGS_TAIL=1 make logs` needs to be added.
+
+The following table outlines the most appropriate replacement commands to use.
+
+v1 Command             | v2 Command
+-----------------------|---------------------------
+`./run.sh`             | `LOGS_TAIL=1 make up logs`
+`make start`           | `LOGS_TAIL=1 make up logs`
+`make start-detatched` | `make up`
+`make stop`            | `make stop`
+`make down`            | `make down`
+`make clean`           | `make clean`
+`make restart`         | `make restart`
+
+In v2, the above commands can be limited to a single service by setting the `SERVICE` variable. For example:
+
+```shell
+SERVICE=zebedee make up
+SERVICE=zebedee make logs
+```
+
+For more information about the less standard v2 make targets, see [v2 Make targets](../README.md#make-targets).
+
+## CMD and elasticsearch
+
+The ONS website and CMD both require Elasticsearch but (annoyingly) require different versions. The `docker-compose.yml` will start 2 instances.
+
+**Note:** The default ports for Elasticsearch is usually `9200` & `9300` however in order to avoid a port conflict when running 2 different versions on the same box at the same time the CMD instance is set to use ports `10200` & `10300`.
+
+:warning: **Gotcha Warning** :warning:
+You'll need to overwrite your ES config for the `dp-dimension-search-builder` and `dp-dimension-search-api` to use ports `10200` & `10300` to ensure they are using the correct instance.

--- a/v2/stacks/v1-compat/README.md
+++ b/v2/stacks/v1-compat/README.md
@@ -59,11 +59,18 @@ SERVICE=zebedee make logs
 
 For more information about the less standard v2 make targets, see [v2 Make targets](../README.md#make-targets).
 
-## CMD and elasticsearch
+## Working with multiple Elasticsearches
 
-The ONS website and CMD both require Elasticsearch but (annoyingly) require different versions. The `docker-compose.yml` will start 2 instances.
+This stack contains three different elasticsearch instances. In order to allow locally running apps to connect, you will need to override the default ports configured in those apps.
 
-**Note:** The default ports for Elasticsearch is usually `9200` & `9300` however in order to avoid a port conflict when running 2 different versions on the same box at the same time the CMD instance is set to use ports `10200` & `10300`.
+### Legacy Core
 
-:warning: **Gotcha Warning** :warning:
-You'll need to overwrite your ES config for the `dp-dimension-search-builder` and `dp-dimension-search-api` to use ports `10200` & `10300` to ensure they are using the correct instance.
+The legacy core will use the `elasticsearch` instance so `zebedee` and `babbage` can continue to use the default ports without change.
+
+### CMD
+
+You'll need to overwrite your ES config for the `dp-dimension-search-builder` and `dp-dimension-search-api` to use ports for the `cmdelasticsearch` instance (i.e. `10200` & `10300`) to ensure they are using the correct instance.
+
+### Search Service
+
+You'll need to overwrite your ES config for the `dp-search-api` and `dp-search-data-importer` to use ports for the `sitewideelasticsearch` instance (i.e. `11200` & `11300`) to ensure they are using the correct instance.

--- a/v2/stacks/v1-compat/default.env
+++ b/v2/stacks/v1-compat/default.env
@@ -1,0 +1,12 @@
+# -- Global variable overrides --
+
+# -- Paths --
+PATH_MANIFESTS="../../manifests"
+PATH_PROVISIONING="../../provisioning"
+
+# -- Docker compose vars --
+# https://docs.docker.com/compose/environment-variables/envvars/
+COMPOSE_FILE=services.yml
+COMPOSE_PATH_SEPARATOR=:
+COMPOSE_PROJECT_NAME=v1-compat
+DOCKER_BUILDKIT=0

--- a/v2/stacks/v1-compat/services.yml
+++ b/v2/stacks/v1-compat/services.yml
@@ -1,0 +1,49 @@
+services:
+  elasticsearch:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/elasticsearch.yml
+      service: elasticsearch
+  cmdelasticsearch:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/elasticsearch.yml
+      service: cmdelasticsearch
+  sitewideelasticsearch:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/elasticsearch.yml
+      service: sitewideelasticsearch
+  highcharts:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/highcharts.yml
+      service: highcharts
+  mongodb:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/mongo.yml
+      service: mongodb
+    volumes:
+      - ${PATH_PROVISIONING}/mongo/init.js:/docker-entrypoint-initdb.d/init.js:ro
+  zookeeper-1:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka.yml
+      service: zookeeper-1
+  kafka-1:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka.yml
+      service: kafka-1
+    depends_on:
+      - zookeeper-1
+  kafka-2:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka.yml
+      service: kafka-2
+    depends_on:
+      - zookeeper-1
+  kafka-3:
+    extends:
+      file: ${PATH_MANIFESTS}/deps/kafka.yml
+      service: kafka-3
+    depends_on:
+      - zookeeper-1
+  mathjax:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/mathjax-api.yml
+      service: mathjax


### PR DESCRIPTION
In preparation for the original "v1" stack being retired, this adds a `v1-compat` stack to v2 that provides the same services as v1 using the v2 structure. This stack is intended to ease the migration off of v1 so that it can be retired more quickly.

To aid in migration, the v1 stack has had deprecation notices pointing to the appropriate migration guidance.

As part of the `v1-compat` stack, mathjax-api has been added to v2. ⚠️  This change is dependent on the fixes to the mathjax API build from https://github.com/ONSdigital/mathjax-api/pull/2, please ensure you are using those changes when testing.

A health check has also been added for highcharts to aid in debugging as well as the repo url so that the repo will be cloned even though we are still using the pre-built image in the stack for now.