### PR TITLE
Upgrade local mongo version

### DIFF
--- a/v2/manifests/deps/mongo.yml
+++ b/v2/manifests/deps/mongo.yml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: mongo:3.6
+    image: mongo:5.0
     expose:
       - "27017"
     ports:


### PR DESCRIPTION
Upgrade mongo version to 5.0

mongodb is actually out of support for 5.0 but the cross-compatibility with documentdb is only up to version 5 as far as I can tell. 

https://www.mongodb.com/legal/support-policy/lifecycles
https://docs.aws.amazon.com/documentdb/latest/developerguide/compatibility.html