### PR TITLE
Fix failed log verify

### DIFF
--- a/v2/stacks/common.mk
+++ b/v2/stacks/common.mk
@@ -40,8 +40,8 @@ verify-service: $(LOCAL_ENV_FILE)
 			[[ "$(SERVICE)" = $$svc ]] && exit 0;					\
 		done;										\
 	done;											\
-	echo "\033[31m""service $(SERVICE) does not exist in stack. Failed to verify.\033[0m" >&2
-	@exit 4
+	echo "\033[31m""service $(SERVICE) does not exist in stack. Failed to verify.\033[0m" >&2; \
+	exit 4
 
 .PHONY: colima-start
 colima-start:


### PR DESCRIPTION
Fixes issues with new logging for failed verification. 

I tested this by doing the following:

```sh
cd v2/stacks/legacy-core-web
# I removed the dependency between dp-frontend-router and dp-api-router at this stage
make up SERVICE=dp-frontend-router
# dp-frontend-router should come up
make health SERVICE=dp-frontend-router
# dp-frontend-router health should be displayed
make health
# stack health should be displayed
make health SERVICE=dp-test
# error should be displayed (not happy it cascades, but that's for another day)
make down
# service should come down
make up SERVICE=dp-test
# error should be displayed
make up
# service should come up
```