### PR TITLE
add topic api to dataset catalogue stack

### DIFF
--- a/v2/stacks/dataset-catalogue/Makefile
+++ b/v2/stacks/dataset-catalogue/Makefile
@@ -6,3 +6,26 @@ init: base-init
 	# Add stack specific initialisation logic here
 
 # Add any stack specific helper targets here
+
+.PHONY: seed-topic-api
+seed-topic-api:
+	@echo "Seeding topic API database..."
+	@if [ -d "$$HOME/src/github.com/ONSdigital/dp-topic-api" ]; then \
+		echo "Found dp-topic-api at $$HOME/src/github.com/ONSdigital/dp-topic-api"; \
+		cd "$$HOME/src/github.com/ONSdigital/dp-topic-api" && make database-seed; \
+	else \
+		echo "dp-topic-api not found at $$HOME/src/github.com/ONSdigital/dp-topic-api"; \
+		echo "Please provide the path to the dp-topic-api directory on your system:"; \
+		read -p "Path to dp-topic-api: " custom_path; \
+		if [ -d "$$custom_path" ]; then \
+			cd "$$custom_path" && make database-seed; \
+		else \
+			echo "Invalid path. Please ensure dp-topic-api is cloned somewhere on your system."; \
+			exit 1; \
+		fi; \
+	fi
+
+.PHONY: up-with-seed
+up-with-seed:
+	$(MAKE) up
+	$(MAKE) seed-topic-api

--- a/v2/stacks/dataset-catalogue/README.md
+++ b/v2/stacks/dataset-catalogue/README.md
@@ -29,4 +29,26 @@ To run the stack:
    make up
    ```
 
+To run the stack with dp-topic-api database seeded:
+
+Follow the prerequsites for installing `mongosh` here - `https://github.com/ONSdigital/dp-topic-api/tree/develop/scripts`
+
+Run:
+
+   ```shell
+   make up-with-seed
+   ```
+
+This assumes that the location of dp-topic-api on your system is `/Users/{your username}/src/github.com/ONSdigital/dp-topic-api`
+
+If that is not the correct location, you will be prompted to input a custom location for dp-topic-api on your system.
+
+Once the correct location is found, you should see something like:
+
+   ```shell
+Found dp-topic-api at /Users/{your username}/src/github.com/ONSdigital/dp-topic-api
+mongosh localhost:27017/topics ./scripts/seed-database/index.js
+creating collections
+   ```
+
 For more information on working with the stack and other make targets, see the [general stack guidance](../README.md#general-guidance-for-each-stack).

--- a/v2/stacks/dataset-catalogue/core-ons.yml
+++ b/v2/stacks/dataset-catalogue/core-ons.yml
@@ -66,3 +66,12 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dis-data-admin-ui.yml
       service: dis-data-admin-ui
+  dp-topic-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-topic-api.yml
+      service: dp-topic-api
+    environment:
+      ZEBEDEE_URL:       "http://dis-authentication-stub:29500"
+    depends_on:
+      dp-api-router:
+        condition: service_healthy


### PR DESCRIPTION
- add topic api to dataset-catalogue stack
- add script to seed topic api database

To test locally, follow the instructions in the updated readme, and then check the topics database in your local mongo connection to confirm that the topics have been seeded