### PR TITLE
Simplify auth stack

### DIFF
--- a/v2/stacks/auth/README.md
+++ b/v2/stacks/auth/README.md
@@ -4,6 +4,14 @@ This stack deploys the necessary services and dependencies to work with the auth
 
 The auth stack uses the sandbox cognito instance to store users and their permissions.
 
+This stack is for testing and working directly with auth and is not designed to run all services. If you wish to add auth to your stack you can either add `dp-authorisation-stub` or to work directly with auth you can add:
+
+- florence
+- dp-identity-api
+- dp-api-router (if you don't have it already)
+
+You would then follow the steps below to add the appropriate environment variables to contact sandbox cognito. 
+
 ## Getting secrets
 
 To run this stack you will need to obtain the relevant secrets for the `local.env` file, which **must not be committed**:
@@ -51,3 +59,17 @@ To get the aws values from the dashboard do the following:
 - Copy the values into your local.env file. Delete the word 'export' from each line. But keep the quotes around the values. NB. These are the only values in your local.env that may need to have quotes around them.
 
 Note that the AWS_SESSION_TOKEN is only valid for 12 hours. Once the token has expired you would need to stop the stack, retrieve and set new credentials before running the stack again.
+
+## Testing
+
+To know this stack has worked you can do the following things:
+
+- [login to florence](http://localhost:8081/florence/login) with your sandbox login
+- log out of florence
+- "forget" your password
+- view all users [via the api](http://localhost:8081/florence/api/v1/users)
+- view all groups [via the api](http://localhost:8081/florence/api/v1/groups)
+- CRUD users in florence (if you're an admin)
+- CRUD groups in florence (if you're an admin)
+
+This list is not definitive and should be taken as a guide only.

--- a/v2/stacks/auth/core-ons.yml
+++ b/v2/stacks/auth/core-ons.yml
@@ -42,47 +42,10 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/sixteens.yml
       service: sixteens
-  dp-files-api:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-files-api.yml
-      service: dp-files-api
-    environment:
-      KAFKA_ADDR: 'kafka-1:9092,kafka-2:9093,kafka-3:9094'
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
   the-train:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/the-train.yml
       service: the-train
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  dp-publishing-dataset-controller:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-publishing-dataset-controller.yml
-      service: dp-publishing-dataset-controller
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  dp-design-system:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-design-system.yml
-      service: dp-design-system
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  dp-image-api:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-image-api.yml
-      service: dp-image-api
-    depends_on:
-      dp-api-router:
-        condition: service_healthy
-  dp-image-importer:
-    extends:
-      file: ${PATH_MANIFESTS}/core-ons/dp-image-importer.yml
-      service: dp-image-importer
     depends_on:
       dp-api-router:
         condition: service_healthy

--- a/v2/stacks/auth/deps.yml
+++ b/v2/stacks/auth/deps.yml
@@ -1,46 +1,4 @@
 services:
-  mongodb:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/mongo.yml
-      service: mongodb
-    volumes:
-      - ${PATH_PROVISIONING}/mongo/init.js:/docker-entrypoint-initdb.d/init.js:ro
-  zookeeper-1:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/kafka.yml
-      service: zookeeper-1
-  kafka-1:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/kafka.yml
-      service: kafka-1
-    depends_on:
-      - zookeeper-1
-  kafka-2:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/kafka.yml
-      service: kafka-2
-    depends_on:
-      - zookeeper-1
-  kafka-3:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/kafka.yml
-      service: kafka-3
-    depends_on:
-      - zookeeper-1
-  vault:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/vault.yml
-      service: vault
-  kowl:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/kafka-tools.yml
-      service: kowl
-    depends_on:
-      - zookeeper-1
-  localstack:
-    extends:
-      file: ${PATH_MANIFESTS}/deps/localstack.yml
-      service: localstack
   elasticsearch:
     extends:
       file: ${PATH_MANIFESTS}/deps/elasticsearch.yml


### PR DESCRIPTION
Simplified the auth stack to just be for testing auth directly. 

This means removing:
- dp-image-api and dp-image-importer - only used for homepage image uploads (homepage controller is not in this stack) and are reliant on a few other things not present in the stack either
- dp-publishing-dataset-controller - not relevant for core auth stack testing
- dp-files-api - not relevant for core auth stack testing
- removed kafka as only used by dp-image-importer
- removed mongodb as only used by dp-image-api and dp-files-api
- removed localstack as only used by dp-image-api and dp-files-api

If devs want auth in their stack in future they can follow the directs in the readme. This stack is strictly limited to auth service testing, not how auth interacts with other services. 