### PR TITLE
Adding seed permissions database step to dataset-catalogue stack

### DIFF
--- a/v2/stacks/dataset-catalogue/Makefile
+++ b/v2/stacks/dataset-catalogue/Makefile
@@ -25,7 +25,26 @@ seed-topic-api:
 		fi; \
 	fi
 
+.PHONY: seed-permissions-api
+seed-permissions-api:
+	@echo "Seeding permissions API database..."
+	@if [ -d "$$HOME/src/github.com/ONSdigital/dp-permissions-api" ]; then \
+		echo "Found dp-permissions-api at $$HOME/src/github.com/ONSdigital/dp-permissions-api"; \
+		cd "$$HOME/src/github.com/ONSdigital/dp-permissions-api/import-script" && go run import.go; \
+	else \
+		echo "dp-permissions-api not found at $$HOME/src/github.com/ONSdigital/dp-permissions-api"; \
+		echo "Please provide the path to the dp-permissions-api directory on your system:"; \
+		read -p "Path to dp-permissions-api: " custom_path; \
+		if [ -d "$$custom_path" ]; then \
+			cd "$$custom_path/import-script" && go run import.go; \
+		else \
+			echo "Invalid path. Please ensure dp-permissions-api is cloned somewhere on your system."; \
+			exit 1; \
+		fi; \
+	fi
+
 .PHONY: up-with-seed
 up-with-seed:
 	$(MAKE) up
 	$(MAKE) seed-topic-api
+	$(MAKE) seed-permissions-api

--- a/v2/stacks/dataset-catalogue/README.md
+++ b/v2/stacks/dataset-catalogue/README.md
@@ -29,7 +29,7 @@ To run the stack:
    make up
    ```
 
-To run the stack with dp-topic-api database seeded:
+To run the stack with dp-topic-api and dp-permissions-api database seeded:
 
 Follow the prerequsites for installing `mongosh` here - `https://github.com/ONSdigital/dp-topic-api/tree/develop/scripts`
 
@@ -39,9 +39,9 @@ Run:
    make up-with-seed
    ```
 
-This assumes that the location of dp-topic-api on your system is `/Users/{your username}/src/github.com/ONSdigital/dp-topic-api`
+This assumes that the location of dp-topic-api on your system is `/Users/{your username}/src/github.com/ONSdigital/dp-topic-api` and that dp-permissions-api is `/Users/{your username}/src/github.com/ONSdigital/dp-permissions-api`
 
-If that is not the correct location, you will be prompted to input a custom location for dp-topic-api on your system.
+If that is not the correct location, you will be prompted to input a custom location for dp-topic-api or dp-permissions-api on your system.
 
 Once the correct location is found, you should see something like:
 
@@ -49,6 +49,9 @@ Once the correct location is found, you should see something like:
 Found dp-topic-api at /Users/{your username}/src/github.com/ONSdigital/dp-topic-api
 mongosh localhost:27017/topics ./scripts/seed-database/index.js
 creating collections
+
+Seeding permissions API database...
+Found dp-permissions-api at /Users/{your username}/src/github.com/ONSdigital/dp-permissions-api
    ```
 
 For more information on working with the stack and other make targets, see the [general stack guidance](../README.md#general-guidance-for-each-stack).


### PR DESCRIPTION
Adding seed permissions database step to dataset-catalogue stack, so that auth v2 can be used with bundle-api.