### PR TITLE
update bundle events record

### DIFF
--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/bundle-events.json
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/bundle-events.json
@@ -1,11 +1,13 @@
 {
-  "created_at": "2025-05-15T09:30:42.111Z",
+  "created_at": {
+    "$date":"2025-05-15T09:30:42.111Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
   },
   "action": "CREATE",
-  "resource": "/bundles/bundle-1",
+  "resource": "/bundles/bundle-1/contents/content-item-1",
   "content_item": {
     "id": "content-item-1",
     "bundle_id": "bundle-1",
@@ -23,7 +25,9 @@
   }
 }
 {
-  "created_at": "2025-05-15T09:35:18.222Z",
+  "created_at": {
+    "$date":"2025-05-15T09:35:18.222Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -53,7 +57,9 @@
   }
 }
 {
-  "created_at": "2025-05-18T14:22:39.876Z",
+  "created_at": {
+    "$date":"2025-05-18T14:22:39.876Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -82,7 +88,9 @@
   }
 }
 {
-  "created_at": "2025-05-20T10:45:12.321Z",
+  "created_at": {
+    "$date":"2025-05-20T10:45:12.321Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -111,7 +119,9 @@
   }
 }
 {
-  "created_at": "2025-05-22T15:33:27.654Z",
+  "created_at": {
+    "$date":"2025-05-22T15:33:27.654Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -140,7 +150,9 @@
   }
 }
 {
-  "created_at": "2025-05-01T09:12:34.567Z",
+  "created_at": {
+    "$date":"2025-05-01T09:12:34.567Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -169,7 +181,9 @@
   }
 }
 {
-  "created_at": "2025-05-05T13:22:45.678Z",
+  "created_at": {
+    "$date":"2025-05-05T13:22:45.678Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -198,7 +212,9 @@
   }
 }
 {
-  "created_at": "2025-05-10T08:22:33.444Z",
+  "created_at": {
+    "$date":"2025-05-10T08:22:33.444Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -227,7 +243,9 @@
   }
 }
 {
-  "created_at": "2025-05-12T11:15:27.333Z",
+  "created_at": {
+    "$date":"2025-05-12T11:15:27.333Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"
@@ -256,7 +274,9 @@
   }
 }
 {
-  "created_at": "2025-05-22T15:40:58.987Z",
+  "created_at": {
+    "$date":"2025-05-22T15:40:58.987Z"
+  },
   "requested_by": {
     "id": "0889d599-3f0e-4564-9d6e-9455a6b73da7",
     "email": "publisher@ons.gov.uk"

--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/bundle-events.json
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/bundle-events.json
@@ -6,25 +6,20 @@
   },
   "action": "CREATE",
   "resource": "/bundles/bundle-1",
-  "bundle": {
-      "bundle_type": "MANUAL",
-      "created_by": {
-        "email": "publisher@ons.gov.uk"
-      },
-      "created_at": "2025-04-04T07:00:00.000Z",
-      "id": "bundle-1",
-      "last_updated_by": {
-        "email": "publisher@ons.gov.uk"
-      },
-      "preview_teams": [
-        {
-          "id": "1253e849-01fd-4662-bee2-63253538da93"
-        }
-      ],
-      "state": "APPROVED",
-      "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
-      "managed_by": "WAGTAIL"
+  "content_item": {
+    "id": "content-item-1",
+    "bundle_id": "bundle-1",
+    "content_type": "DATASET",
+    "metadata": {
+      "dataset_id": "test-dataset-1",
+      "edition_id": "2021",
+      "version_id": 1,
+      "title": "Test Dataset 1"
+    },
+    "links": {
+      "edit": "https://publishing.ons.gov.uk/data-admin/edit/datasets/test-dataset-1/editions/2021/versions/1",
+      "preview": "https://publishing.ons.gov.uk/data-admin/preview/datasets/test-dataset-1/editions/2021/versions/1"
+    }
   }
 }
 {

--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/bundle-events.json
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/bundle-events.json
@@ -39,7 +39,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-2",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -49,10 +51,14 @@
           "id": "1253e849-01fd-4662-bee2-63253538da93"
         }
       ],
-      "scheduled_at": "2025-04-05T07:00:00.000Z",
+      "scheduled_at": {
+        "$date":"2025-04-05T07:00:00.000Z"
+      },
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -71,7 +77,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-3",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -83,7 +91,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -102,7 +112,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-4",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -114,7 +126,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -133,7 +147,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-5",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -145,7 +161,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -164,7 +182,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-6",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -176,7 +196,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -195,7 +217,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-7",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -207,7 +231,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -226,7 +252,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-8",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -238,7 +266,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -257,7 +287,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-9",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -269,7 +301,9 @@
       ],
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }
@@ -288,7 +322,9 @@
       "created_by": {
         "email": "publisher@ons.gov.uk"
       },
-      "created_at": "2025-04-04T07:00:00.000Z",
+      "created_at": {
+        "$date":"2025-04-04T07:00:00.000Z"
+      },
       "id": "bundle-10",
       "last_updated_by": {
         "email": "publisher@ons.gov.uk"
@@ -298,10 +334,14 @@
           "id": "1253e849-01fd-4662-bee2-63253538da93"
         }
       ],
-      "scheduled_at": "2025-04-05T07:00:00.000Z",
+      "scheduled_at": {
+        "$date":"2025-04-05T07:00:00.000Z"
+      },
       "state": "APPROVED",
       "title": "CPI March 2025",
-      "updated_at": "2025-04-04T10:00:00.000Z",
+      "updated_at": {
+        "$date":"2025-04-04T10:00:00.000Z"
+      },
       "managed_by": "WAGTAIL"
   }
 }

--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/init.js
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/init.js
@@ -230,3 +230,13 @@ for (database of databases) {
         }
     }
 }
+
+db = db.getSiblingDB("bundles");
+db.bundle_events.find({}).forEach(function(doc) {
+    if (typeof doc.created_at === "string") {
+        db.bundle_events.updateOne(
+            {_id: doc._id},
+            {$set: {"created_at": new ISODate(doc.created_at)}}
+        );
+    }
+});

--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/init.js
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/init.js
@@ -230,13 +230,3 @@ for (database of databases) {
         }
     }
 }
-
-db = db.getSiblingDB("bundles");
-db.bundle_events.find({}).forEach(function(doc) {
-    if (typeof doc.created_at === "string") {
-        db.bundle_events.updateOne(
-            {_id: doc._id},
-            {$set: {"created_at": new ISODate(doc.created_at)}}
-        );
-    }
-});


### PR DESCRIPTION
### What

- The `created_at` fields need to be in the proper ISO date format to match the records in sandbox 
- Added a small js script to update the local database initialisation for bundle events to convert string dates to ISODate objects for the `created_at` field

- Bundle Events can have either a `bundle` or `content_item` field, so at least one bundle event record needs to have a `content_item` field to allow for local testing (all bundle events are currently only using the `bundle` field)
- Updated the `bundle-1` record to use the `content_item` field instead of `bundle` field

### How to review

Confirm changes make sense

### Who can review

Anyone
