### PR TITLE
Add early exit if no github repos

### DIFF
--- a/v2/scripts/clone.sh
+++ b/v2/scripts/clone.sh
@@ -21,11 +21,12 @@ REPO_SSH_URL_REGEX='^(git@)?github.com:([^\/]+)\/([^\/]+)\/?(\.git)?$'
 which git > /dev/null || fatal "git not installed"
 which yq  > /dev/null || fatal "yq not installed"
 
-# Test ssh to github
-test_github_ssh
-
 # Get list of repo urls from docker compose config
 repos=( $(make list-repos) )
+[ ${#repos[@]} -eq 0 ] && info "no github repos in stack" && exit 0
+
+# Test ssh to github
+test_github_ssh
 
 errors=()
 for repo_url in ${repos[@]}; do


### PR DESCRIPTION
### What

Added an early exit from the clone script if there are no repos. Otherwise it attempts to test github ssh when it doesn't need to. 

### How to review

In legacy-core-web run `SERVICE=elasticsearch make up` and see that it reports "no github repos in stack" and doesn't attempt to ssh at that stage - it does later for dp-zebedee-content but that is not part of this change. 

### Who can review

Not me. 