### PR TITLE
Fix dis-data-admin-ui request issue and add url to dis-authentication-stub for reverse proxy

### DIFF
--- a/v2/stacks/dataset-catalogue/core-ons.yml
+++ b/v2/stacks/dataset-catalogue/core-ons.yml
@@ -68,6 +68,8 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dis-data-admin-ui.yml
       service: dis-data-admin-ui
+    environment:
+      API_ROUTER_URL: "http://dp-api-router:23200/v1"
   dp-topic-api:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-topic-api.yml

--- a/v2/stacks/dataset-catalogue/data.yml
+++ b/v2/stacks/dataset-catalogue/data.yml
@@ -13,3 +13,5 @@ services:
     extends:
       file: ${PATH_MANIFESTS}/stubs/dis-authentication-stub.yml
       service: dis-authentication-stub
+    environment:
+      DATA_ADMIN_URL: "http://dis-data-admin-ui:29400/data-admin"


### PR DESCRIPTION
### What

Fix dis-data-admin-ui request issue and add url to dis-authentication-stub for reverse proxy

### How to review

Start up dataset catalogue stack with both `dis-authentication-stub` and `dis-data-admin-ui` enabled. Try access `dis-data-admin-ui`via the proxy go to http://localhost:29500/data-admin/series

### Who can review

Anyone
