### PR TITLE
point to dockerfile.local

### DIFF
--- a/v2/manifests/core-ons/dp-files-api.yml
+++ b/v2/manifests/core-ons/dp-files-api.yml
@@ -3,7 +3,7 @@ services:
     x-repo-url: "https://github.com/ONSdigital/dp-files-api"
     build:
       context: ${DP_REPO_DIR:-../../../..}/dp-files-api
-      dockerfile: Dockerfile-local
+      dockerfile: Dockerfile.local
     volumes:
       - ${DP_REPO_DIR:-../../../..}/dp-files-api:/service
     expose:

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -3,7 +3,7 @@ services:
     x-repo-url: "https://github.com/ONSdigital/dp-static-file-publisher"
     build:
       context: ${DP_REPO_DIR:-../../../..}/dp-static-file-publisher
-      dockerfile: Dockerfile-local
+      dockerfile: Dockerfile.local
     command:
       - reflex
       - -d


### PR DESCRIPTION
### What

- `dp-files-api` and `dp-static-file-publisher` amended to use `Dockerfile.local` as those repositories only contain `.local`

### How to review

Check changes are ok
- pull the latest develop branch for dp-files-api and dp-static-file-publisher (or run `make pull`)
- `make up-with-seed` for the `dataset-catalogue` and ensure all services are healthy

### Who can review

Anyone
