### PR TITLE
docs: localstack instructions for dataset catalogue stack

### DIFF
--- a/v2/stacks/dataset-catalogue/README.md
+++ b/v2/stacks/dataset-catalogue/README.md
@@ -55,3 +55,45 @@ Found dp-permissions-api at /Users/{your username}/src/github.com/ONSdigital/dp-
    ```
 
 For more information on working with the stack and other make targets, see the [general stack guidance](../README.md#general-guidance-for-each-stack).
+
+## Using `localstack` for running Dataset Ingest pipelines locally
+
+The `localstack` service can be used to run the Dataset Ingest pipelines locally. To interact with the Dataset Ingest pipelines, run `make up-with-seed` as normal, then run the following commands in the `dis-infra-data-pipeline-stack` repo:
+
+1. From the root directory, make sure that the Python virtual environment is activated, and install the necessary Python packages:
+
+   ```bash
+   source .venv/bin/activate
+   make install
+   ```
+
+   This will install the `terraform-local` package, which is required to apply the pipeline infrastructure.
+
+2. Navigate to `environments/60_local` and run:
+
+   ```bash
+   tflocal init
+   tflocal apply
+   ```
+
+   Enter `yes` to apply the pipeline infrastructure.
+
+3. To simulate the Slack notification channel, in a separate terminal, run `server.py` in `environments/60_local`:
+
+   ```bash
+   cd environments/60_local
+   python server.py
+   ```
+
+3. In a new terminal, verify the email address to use as `SES_EMAIL_IDENTITY`:
+
+   ```bash
+   aws ses verify-email-identity --email-address example@example.com --region us-east-1 --endpoint-url=http://localhost:4566
+   ```
+
+4. Submit a zip file to the `ingest-datasets` bucket using the `put-object` command - this will trigger the pipeline:
+
+   ```bash
+   aws s3api --endpoint-url=http://localhost:4566 put-object --bucket ingest-datasets --key input/<filename>.zip --body <path/to/filename>.zip
+   ```
+

--- a/v2/stacks/dataset-catalogue/deps.yml
+++ b/v2/stacks/dataset-catalogue/deps.yml
@@ -41,7 +41,9 @@ services:
       - '4563-4599:4563-4599'
       - '8055:8080'
     environment:
-      - SERVICES=s3,lambda,iam,logs,secretsmanager
+      - SERVICES=s3,lambda,iam,logs,secretsmanager,ses
+      - DEBUG=1
+      - LS_LOG=trace
   elasticsearch:
     extends:
       file: ${PATH_MANIFESTS}/deps/elasticsearch.yml


### PR DESCRIPTION
### What

Instructions on running `localstack` for local testing of Dataset Ingest pipeline infrastructure and operations added to `https://github.com/ONSdigital/dp-compose/blob/main/v2/stacks/dataset-catalogue/README.md`.

### How to review

Check that the instructions are sufficient to get the environment working and run the pipeline locally.

### Who can review

Anyone.
