### PR TITLE
Add legacy cache api to legacy stack

### DIFF
--- a/v2/manifests/core-ons/dp-legacy-cache-api.yml
+++ b/v2/manifests/core-ons/dp-legacy-cache-api.yml
@@ -1,0 +1,27 @@
+services:
+  dp-legacy-cache-api:
+    x-repo-url: "https://github.com/ONSdigital/dp-legacy-cache-api"
+    build:
+      context: ${DP_REPO_DIR:-../../../..}/dp-legacy-cache-api
+      dockerfile: Dockerfile.local
+    command:
+      - make
+      - debug
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dp-legacy-cache-api:/dp-legacy-cache-api
+    expose:
+      - "29100"
+    ports:
+      - 29100:29100
+    restart: unless-stopped
+    environment:
+      BIND_ADDR:         ${BIND_ADDR:-:29100}
+      DEBUG:             ${DEBUG:-false}
+      IS_PUBLISHING:     ${IS_PUBLISHING:-true}
+      MONGODB_BIND_ADDR: ${MONGODB_BIND_ADDR:-mongodb:27017}
+      ZEBEDEE_URL:       ${ZEBEDEE_URL:-http://zebedee:8082}
+    healthcheck:
+      test: ["CMD", "curl", "-sSf", "http://localhost:29100/health"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/manifests/core-ons/zebedee.yml
+++ b/v2/manifests/core-ons/zebedee.yml
@@ -42,7 +42,7 @@ services:
       AWS_COGNITO_SIGNING_KEY_TWO:    ${AWS_COGNITO_SIGNING_KEY_TWO:-"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtvDfudfY9n+8sFJmHGFfgbKqKf8iiEcbvRXNMEi9qd2NGAekhdNJKdeW3sMSwR+sb4Ly6IypowCE2eueYk/GatzYyyolWny/Krdp0EWPT/PnK8Iq1FTIuHxFb08B8iLnH/2nKqgOjVvwEU4eSBh0YHKti2v77a+a4bnx6aOC2YkF2AyIRmbXAHaq4Js9u33X8gGMXZcVsxcSpG8Py/NJ3s+PLKebQFd28S1Jl/89JDcUv4/3DF+u8k9nxkGlaSEcwF7OIyj+cnSa7gm3PadTO+m/96JENyNaLTjpPE7yiHKDpwMP04LZeAF+QhpnQsCgOTNmP5ogFzQtwOyX25/FmQIDAQAB"}
       AWS_COGNITO_KEY_ID_ONE:         ${AWS_COGNITO_KEY_ID_ONE:-"2a8vXmIK67ZZ3hFZ/DwQATgvqZgRBFjuuVavlw3zEwo="}
       AWS_COGNITO_KEY_ID_TWO:         ${AWS_COGNITO_KEY_ID_TWO:-"GRBevIroJzPBvaGaL9xm4x/6rQGkbKxi3wLtcTiGymE="}
-      scheduled_publishing_enabled:   "false"
+      scheduled_publishing_enabled:   ${scheduled_publishing_enabled:-"false"}
       OTEL_JAVAAGENT_ENABLED:         ${OTEL_JAVAAGENT_ENABLED:-"false"}
       brian_url:                      "http://project-brian:8083"
       BABBAGE_URL:                    "http://babbage:8080"
@@ -50,6 +50,8 @@ services:
       ENABLE_REDIRECT_API:            ${ENABLE_REDIRECT_API:-false}
       ENABLE_PERMISSIONS_API:         ${ENABLE_PERMISSIONS_API:-true}
       PERMISSIONS_API_URL:            ${PERMISSIONS_API_URL:-http://dp-permissions-api:25400}
+      LEGACY_CACHE_API_URL:           ${LEGACY_CACHE_API_URL:-http://dp-legacy-cache-api:29100}
+      LEGACY_CACHE_API_AUTH_TOKEN:    ${LEGACY_CACHE_API_AUTH_TOKEN:-fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67}
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:8082/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/provisioning/mongo/init.js
+++ b/v2/provisioning/mongo/init.js
@@ -44,6 +44,10 @@ var databases = [
 	{
 		name: "migrations",
 		collections: [{"name":"jobs"}, {"name":"tasks"}, {"name":"events"}, {"name":"counters"}]
+	},
+	{
+		name: "cache",
+		collections: [{"name":"cachetimes"}]
 	}
 ];
 

--- a/v2/stacks/legacy-core-publishing/README.md
+++ b/v2/stacks/legacy-core-publishing/README.md
@@ -46,7 +46,7 @@ To run the stack:
     COMPOSE_FILE=core-deps.yml:core.yml
      ```
 
-   To add the caching servies for scheduled publications, you can set the `COMPOSE_FILE` and `scheduled_publishing_enabled` as follows:
+   To add the caching services for scheduled publications, you can set the `COMPOSE_FILE` and `scheduled_publishing_enabled` as follows:
 
    ```shell
    COMPOSE_FILE=core-deps.yml:core.yml:cache.yml

--- a/v2/stacks/legacy-core-publishing/README.md
+++ b/v2/stacks/legacy-core-publishing/README.md
@@ -45,7 +45,14 @@ To run the stack:
      ```shell
     COMPOSE_FILE=core-deps.yml:core.yml
      ```
-  
+
+   To add the caching servies for scheduled publications, you can set the `COMPOSE_FILE` and `scheduled_publishing_enabled` as follows:
+
+   ```shell
+   COMPOSE_FILE=core-deps:core.yml:cache.yml
+   scheduled_publishing_enabled=true
+   ```
+
 3. Build and start the stack:
 
    ```shell
@@ -86,10 +93,6 @@ Release page rendering:
 
 - dp-release-calendar-api
 - dp-frontend-release-calendar
-
-Cache Proxy service:
-
-- dp-legacy-cache-api
 
 Timeseries processing and publishing:
 

--- a/v2/stacks/legacy-core-publishing/README.md
+++ b/v2/stacks/legacy-core-publishing/README.md
@@ -49,7 +49,7 @@ To run the stack:
    To add the caching servies for scheduled publications, you can set the `COMPOSE_FILE` and `scheduled_publishing_enabled` as follows:
 
    ```shell
-   COMPOSE_FILE=core-deps:core.yml:cache.yml
+   COMPOSE_FILE=core-deps.yml:core.yml:cache.yml
    scheduled_publishing_enabled=true
    ```
 

--- a/v2/stacks/legacy-core-publishing/cache.yml
+++ b/v2/stacks/legacy-core-publishing/cache.yml
@@ -1,0 +1,10 @@
+services:
+  dp-legacy-cache-api:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dp-legacy-cache-api.yml
+      service: dp-legacy-cache-api
+    depends_on:
+      mongodb:
+        condition: service_healthy
+      zebedee:
+        condition: service_healthy


### PR DESCRIPTION
### What

Add dp-legacy-cache-api to legacy-core-publishing stack

### How to review

Check looks ok - try a scheduled publish and see the times appear in the api. Requires this branch: https://github.com/ONSdigital/dp-legacy-cache-api/pull/53

### Who can review

Not me. 