### PR TITLE
Feature/tidy up dataset catalogue default env

### DIFF
--- a/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
+++ b/v2/manifests/core-ons/dp-frontend-dataset-controller.yml
@@ -24,14 +24,14 @@ services:
       DEBUG:                          ${DEBUG:-false}
       ENABLE_CENSUS_TOPIC_SUBSECTION: ${ENABLE_CENSUS_TOPIC_SUBSECTION:-false}
       ENABLE_NEW_NAVBAR:              ${ENABLE_NEW_NAVBAR:-false}
-      IS_PUBLISHING_MODE:             ${IS_PUBLISHING:-false}
+      IS_PUBLISHING:                  ${IS_PUBLISHING:-false}
       SERVICE_AUTH_TOKEN:             ${SERVICE_AUTH_TOKEN:-fc4089e2e12937861377629b0cd96cf79298a4c5d329a2ebb96664c88df77b67}
       SITE_DOMAIN:                    ${SITE_DOMAIN:-localhost}
       DOWNLOAD_SERVICE_URL:           "http://localhost:23600"
-      PERMISSIONS_API_URL:                ${PERMISSIONS_API_URL:-http://dp-permissions-api:25400}
-      IDENTITY_API_URL:                   ${IDENTITY_API_URL:-http://dis-authentication-stub:29500}
-      IDENTITY_WEB_KEY_SET_URL:           ${IDENTITY_API_URL:-http://dis-authentication-stub:29500}
-      AUTHORISATION_ENABLED:              "true"
+      PERMISSIONS_API_URL:            ${PERMISSIONS_API_URL:-http://dp-permissions-api:25400}
+      IDENTITY_API_URL:               ${IDENTITY_API_URL:-http://dis-authentication-stub:29500}
+      IDENTITY_WEB_KEY_SET_URL:       ${IDENTITY_API_URL:-http://dis-authentication-stub:29500}
+      AUTHORISATION_ENABLED:          "true"
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:20200/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/stacks/dataset-catalogue/default.env
+++ b/v2/stacks/dataset-catalogue/default.env
@@ -1,7 +1,3 @@
-# -- Global variable overrides --
-IS_PUBLISHING="true"
-AUTHORISATION_ENABLED=false
-
 # -- Paths --
 PATH_MANIFESTS="../../manifests"
 PATH_PROVISIONING="../../provisioning"


### PR DESCRIPTION
### What

- Remove duplicated env default vars for `dataset-catalogue`
- Correct `IS_PUBLISHING` env var name for `dp-frontend-dataset-controller`

### How to review

- Check changes are ok

### Who can review

- Anyone
