### PR TITLE
update static-test-dataset links

### DIFF
--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/datasets.json
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/datasets.json
@@ -147,7 +147,7 @@
                 "href": "/datasets/static-test-dataset/editions"
             },
             "latest_version": {
-                "href": "/datasets/static-test-dataset/editions/dataset/versions/2",
+                "href": "/datasets/static-test-dataset/editions/time-series/versions/2",
                 "id": "2"
             },
             "self": {
@@ -205,7 +205,7 @@
                 "href": "/datasets/static-test-dataset/editions"
             },
             "latest_version": {
-                "href": "/datasets/static-test-dataset/editions/dataset/versions/2",
+                "href": "/datasets/static-test-dataset/editions/time-series/versions/2",
                 "id": "2"
             },
             "self": {

--- a/v2/stacks/dataset-catalogue/provisioning/mongodb/versions.json
+++ b/v2/stacks/dataset-catalogue/provisioning/mongodb/versions.json
@@ -22,6 +22,9 @@
         "version": {
             "href": "/datasets/static-test-dataset/editions/time-series/versions/1",
             "id": "1"
+        },
+        "web_page": {
+            "href": "businessindustryandtrade/datasets/static-test-dataset/editions/time-series/versions/1"
         }
     },
     "release_date": "2025-01-26T07:00:00.000Z",
@@ -93,6 +96,9 @@
         "version": {
             "href": "/datasets/static-test-dataset/editions/time-series/versions/2",
             "id": "2"
+        },
+        "web_page": {
+            "href": "businessindustryandtrade/datasets/static-test-dataset/editions/time-series/versions/2"
         }
     },
     "release_date": "2025-01-27T07:00:00.000Z",


### PR DESCRIPTION
### What

- The `test-static-dataset` preset data had incorrect `latest_version` links and the associated versions did not have `web_page` links.

### How to review

- Check changes are ok
- Run dataset-catalogue stack and check `http://localhost:20200/businessindustryandtrade/datasets/static-test-dataset` redirect works in the browser

### Who can review

- Anyone
