### PR TITLE
Add legacy cache purger to legacy core publishing

### DIFF
--- a/v2/manifests/core-ons/dis-legacy-cache-purger.yml
+++ b/v2/manifests/core-ons/dis-legacy-cache-purger.yml
@@ -1,0 +1,17 @@
+services:
+  dis-legacy-cache-purger:
+    build:
+      context: ${DP_REPO_DIR:-../../../..}/dis-legacy-cache-purger
+      dockerfile: Dockerfile.local
+    volumes:
+      - ${DP_REPO_DIR:-../../../..}/dis-legacy-cache-purger:/dis-legacy-cache-purger
+    environment:
+      CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-""}
+      CLOUDFLARE_ZONE_ID: ${CLOUDFLARE_ZONE_ID:-""}
+      ENABLE_CACHE_API: ${ENABLE_CACHE_API:-true}
+      ENABLE_CLOUDFLARE_PURGE: ${ENABLE_CLOUDFLARE_PURGE:-false}
+      ENABLE_SLACK_ALERTS: ${ENABLE_SLACK_ALERTS:-true}
+      LEGACY_CACHE_API_URL: ${LEGACY_CACHE_API_URL:-http://dp-legacy-cache-api:29100}
+      SERVICE_AUTH_TOKEN: ${SERVICE_AUTH_TOKEN:-""}
+      SLACK_API_TOKEN: ${SLACK_API_TOKEN:-""}
+      SLACK_CHANNEL: ${SLACK_CHANNEL:-"#sandbox-publish-log"}

--- a/v2/stacks/legacy-core-publishing/cache.yml
+++ b/v2/stacks/legacy-core-publishing/cache.yml
@@ -8,3 +8,10 @@ services:
         condition: service_healthy
       zebedee:
         condition: service_healthy
+  dis-legacy-cache-purger:
+    extends:
+      file: ${PATH_MANIFESTS}/core-ons/dis-legacy-cache-purger.yml
+      service: dis-legacy-cache-purger
+    depends_on:
+      dp-legacy-cache-api:
+        condition: service_healthy

--- a/v2/stacks/legacy-core-publishing/core.yml
+++ b/v2/stacks/legacy-core-publishing/core.yml
@@ -9,6 +9,7 @@ services:
       PERMISSIONS_API_URL: http://dp-permissions-api:25400
       IDENTITY_API_URL: http://host.docker.internal:25600
       ENABLE_STATIC_FILES_PUBLISHING: "false"
+      SERVICE_AUTH_TOKEN: zebedeeservicetestauthtoken
     extra_hosts:
       - "host.docker.internal:host-gateway"          # localhost mapping for linux
       - "docker.for.mac.host.internal:host-gateway"  # localhost mapping for mac (docker v17.12 to v18.02)

--- a/v2/stacks/legacy-core-publishing/default.env
+++ b/v2/stacks/legacy-core-publishing/default.env
@@ -1,7 +1,7 @@
 # -- Global variable overrides --
 IS_PUBLISHING="true"
 ENABLE_PRIVATE_ENDPOINTS=true
-AUTHORISATION_ENABLED=false
+AUTHORISATION_ENABLED=true
 
 # -- Paths --
 PATH_MANIFESTS="../../manifests"


### PR DESCRIPTION
### What

Add legacy cache purger to legacy core publishing

### How to review

To run it you can see this via:

- cd v2/stacks/legacy-core-publishing
- SERVICE=dis-legacy-cache-purger make up
- SERVICE=dis-legacy-cache-purger make logs LOGS_TAIL=1

Then you can see it run every minute and try to contact the dp-legacy-cache-api

Needs https://github.com/ONSdigital/dis-legacy-cache-purger/pull/14 to run. 

### Who can review

Not me. 