### PR TITLE
set ENABLE_PRIVATE_ENDPOINTS in default.env

### DIFF
--- a/v2/stacks/dataset-catalogue/data.yml
+++ b/v2/stacks/dataset-catalogue/data.yml
@@ -5,7 +5,6 @@ services:
       service: dp-dataset-api
     environment:
       DISABLE_GRAPH_DB_DEPENDENCY: true
-      ENABLE_PRIVATE_ENDPOINTS: true
       ENABLE_URL_REWRITING: true
       ZEBEDEE_URL:       "http://dis-authentication-stub:29500"
       FILES_API_URL:     "http://dp-files-api:26900"

--- a/v2/stacks/dataset-catalogue/default.env
+++ b/v2/stacks/dataset-catalogue/default.env
@@ -11,6 +11,7 @@ COMPOSE_HTTP_TIMEOUT=120
 
 # -- Global variable overrides --
 IS_PUBLISHING="true"
+ENABLE_PRIVATE_ENDPOINTS="true"
 AUTHORISATION_ENABLED="true"
 IDENTITY_API_URL="http://dis-authentication-stub:29500"
 IDENTITY_WEB_KEY_SET_URL="http://dis-authentication-stub:29500"


### PR DESCRIPTION
### What

- Update `default.env` for dataset-catalogue stack so `ENABLE_PRIVATE_ENDPOINTS` is set in one place so switching between web and publishing is easier

### How to review

- check changes are ok

### Who can review

- anyone
