### PR TITLE
Update to ministack

### DIFF
--- a/v2/manifests/core-ons/dp-download-service.yml
+++ b/v2/manifests/core-ons/dp-download-service.yml
@@ -21,7 +21,7 @@ services:
       FILES_API_URL:                ${FILES_API_URL:-http://dp-files-api:26900}
       MINIO_ACCESS_KEY:             "test"
       MINIO_SECRET_KEY:             "test"
-      LOCAL_OBJECT_STORE:           ${LOCALSTACK_URL:-http://localstack:4566}
+      LOCAL_OBJECT_STORE:           ${LOCALSTACK_URL:-http://ministack:4566}
       IMAGE_API_URL:                ${IMAGE_API_URL:-http://dp-image-api:24700}
       FILTER_API_URL:               ${FILTER_API_URL:-http://dp-filter-api:22100}
       DATASET_API_URL:              ${DATASET_API_URL:-http://dp-dataset-api:22000}

--- a/v2/manifests/core-ons/dp-files-api.yml
+++ b/v2/manifests/core-ons/dp-files-api.yml
@@ -33,7 +33,7 @@ services:
       ZEBEDEE_URL:                        ${ZEBEDEE_URL:-http://zebedee:8082}
       AUTHORISATION_ENABLED:              ${AUTHORISATION_ENABLED:-true}
       S3_PRIVATE_BUCKET_NAME:             "testing"
-      LOCALSTACK_HOST:                    ${LOCALSTACK_URL:-http://localstack:4566}
+      LOCALSTACK_HOST:                    ${LOCALSTACK_URL:-http://ministack:4566}
     healthcheck:
       test: ["CMD", "curl", "-sSf", "http://localhost:26900/health"]
       interval: ${HEALTHCHECK_INTERVAL:-30s}

--- a/v2/manifests/core-ons/dp-image-importer.yml
+++ b/v2/manifests/core-ons/dp-image-importer.yml
@@ -27,7 +27,7 @@ services:
       IMAGE_UPLOADED_TOPIC:    ${IMAGE_UPLOADED_TOPIC:-image-uploaded}
       S3_PRIVATE_BUCKET_NAME:  ${S3_PRIVATE_BUCKET_NAME:-testing}
       S3_UPLOADED_BUCKET_NAME: ${S3_PRIVATE_BUCKET_NAME:-uploaded}
-      S3_LOCAL_URL:            ${S3_LOCAL_URL:-http://localstack:4566}
+      S3_LOCAL_URL:            ${S3_LOCAL_URL:-http://ministack:4566}
       S3_LOCAL_ID:             "test"
       S3_LOCAL_SECRET:         "test"
       DOWNLOAD_SERVICE_URL:    ${DOWNLOAD_SERVICE_URL:-http://localhost:23600}

--- a/v2/manifests/core-ons/dp-static-file-publisher.yml
+++ b/v2/manifests/core-ons/dp-static-file-publisher.yml
@@ -39,7 +39,7 @@ services:
       S3_PUBLIC_BUCKET_NAME:              "testing-public"
       FILES_API_URL:                      ${FILES_API_URL:-http://dp-files-api:26900}
       CONSUMER_GROUP:                     "dp-static-file-publisher"
-      S3_LOCAL_URL:                       ${S3_LOCAL_URL:-http://localstack:4566}
+      S3_LOCAL_URL:                       ${S3_LOCAL_URL:-http://ministack:4566}
       S3_LOCAL_ID:                        "test"
       S3_LOCAL_SECRET:                    "test"
       IMAGE_API_URL:                      ${IMAGE_API_URL:-http://dp-image-api:24700}

--- a/v2/manifests/core-ons/dp-upload-service.yml
+++ b/v2/manifests/core-ons/dp-upload-service.yml
@@ -20,7 +20,7 @@ services:
       HEALTHCHECK_INTERVAL:               ${HEALTHCHECK_INTERVAL:-30s}
       BIND_ADDR:                          ":25100"
       AWS_REGION:                         "eu-west-1"
-      LOCALSTACK_HOST:                    ${LOCALSTACK_URL:-http://localstack:4566}
+      LOCALSTACK_HOST:                    ${LOCALSTACK_URL:-http://ministack:4566}
       UPLOAD_BUCKET_NAME:                 ${UPLOAD_BUCKET_NAME:-deprecated}
       STATIC_FILES_ENCRYPTED_BUCKET_NAME: ${STATIC_FILES_ENCRYPTED_BUCKET_NAME:-testing}
       GRACEFUL_SHUTDOWN_TIMEOUT:          "5s"

--- a/v2/manifests/deps/ministack.yml
+++ b/v2/manifests/deps/ministack.yml
@@ -1,0 +1,17 @@
+services:
+  ministack:
+    image: ministackorg/ministack:latest
+    ports:
+      - "4566:4566"
+    environment:
+      - PERSIST_STATE=1
+      - S3_PERSIST=1
+      - LOG_LEVEL=DEBUG
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ../../provisioning/localstack:/etc/localstack/init/ready.d/
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:4566/_ministack/health')"]
+      interval: ${HEALTHCHECK_INTERVAL:-30s}
+      timeout: 10s
+      retries: 10

--- a/v2/stacks/dataset-catalogue/README.md
+++ b/v2/stacks/dataset-catalogue/README.md
@@ -56,9 +56,9 @@ Found dp-permissions-api at {some-path}/dp-permissions-api
 
 For more information on working with the stack and other make targets, see the [general stack guidance](../README.md#general-guidance-for-each-stack).
 
-## Using `localstack` for running Dataset Ingest pipelines locally
+## Using `ministack` for running Dataset Ingest pipelines locally
 
-The `localstack` service can be used to run the Dataset Ingest pipelines locally. The `localstack` container is configured to use Terraform version 1.10.0. You can manage different versions of Terraform using `tfenv`, which can be installed via `brew`:
+The `ministack` service can be used to run the Dataset Ingest pipelines locally. The `ministack` container is configured to use Terraform version 1.10.0. You can manage different versions of Terraform using `tfenv`, which can be installed via `brew`:
 
    ```bash
    brew install tfenv

--- a/v2/stacks/dataset-catalogue/core-ons.yml
+++ b/v2/stacks/dataset-catalogue/core-ons.yml
@@ -19,7 +19,7 @@ services:
       file: ${PATH_MANIFESTS}/core-ons/dp-files-api.yml
       service: dp-files-api
     environment:
-      LOCALSTACK_HOST:    "http://localstack:4566"
+      LOCALSTACK_HOST:    "http://ministack:4566"
   dp-upload-service:
     extends:
       file: ${PATH_MANIFESTS}/core-ons/dp-upload-service.yml
@@ -31,7 +31,7 @@ services:
     environment:
       BUCKET_NAME:       "testing"
       PUBLIC_BUCKET_URL: "http://localhost:14566/testing-public/"
-      LOCALSTACK_HOST:    "http://localstack:4566"
+      LOCALSTACK_HOST:    "http://ministack:4566"
     depends_on:
       dp-api-router:
         condition: service_healthy

--- a/v2/stacks/dataset-catalogue/deps.yml
+++ b/v2/stacks/dataset-catalogue/deps.yml
@@ -33,10 +33,10 @@ services:
       service: kowl
     depends_on:
       - zookeeper-1
-  localstack:
+  ministack:
     extends:
-      file: ${PATH_MANIFESTS}/deps/localstack.yml
-      service: localstack
+      file: ${PATH_MANIFESTS}/deps/ministack.yml
+      service: ministack
     ports:
       - '4563-4599:4563-4599'
       - '8055:8080'

--- a/v2/stacks/static-files-with-auth/deps.yml
+++ b/v2/stacks/static-files-with-auth/deps.yml
@@ -37,7 +37,7 @@ services:
       service: kowl
     depends_on:
       - zookeeper-1
-  localstack:
+  ministack:
     extends:
-      file: ${PATH_MANIFESTS}/deps/localstack.yml
-      service: localstack
+      file: ${PATH_MANIFESTS}/deps/ministack.yml
+      service: ministack

--- a/v2/stacks/static-files/deps.yml
+++ b/v2/stacks/static-files/deps.yml
@@ -31,10 +31,10 @@ services:
       service: mongodb
     volumes:
       - ${PATH_PROVISIONING}/mongo/init.js:/docker-entrypoint-initdb.d/init.js:ro
-  localstack:
+  ministack:
     extends:
-      file: ${PATH_MANIFESTS}/deps/localstack.yml
-      service: localstack
+      file: ${PATH_MANIFESTS}/deps/ministack.yml
+      service: ministack
   http-echo:
     extends:
       file: ${PATH_MANIFESTS}/deps/http-echo.yml


### PR DESCRIPTION
### What

Being as localstack now requires licenses, ministack seems to slot in as a replacement so adding it here for the services owned by the data dissemination team.  CMD is not updated as it is due to be deprecated.

### How to review

Ensure the changes make sense.  For a thorough review, run the dataset-catalogue stack and ensure that creating and publishing editions works as expected.  Pipeline updates will follow in a separate ticket.

### Who can review

Anyone.
